### PR TITLE
index in WhereIndexed should be a continuous sequence

### DIFF
--- a/where_test.go
+++ b/where_test.go
@@ -41,6 +41,9 @@ func TestWhereIndexed(t *testing.T) {
 		{"sstr", func(i int, x interface{}) bool {
 			return x.(rune) != 's' || i == 1
 		}, []interface{}{'s', 't', 'r'}},
+		{"abcde", func(i int, _ interface{}) bool {
+			return i < 2
+		}, []interface{}{'a', 'b'}},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
The test case will show that the first parameter of predicate function in WhereIndexed is not  a continuous sequence