### PR TITLE
Bugfix in WhereIndexed()

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1386,7 +1386,7 @@ func ExampleQuery_WhereIndexed() {
 
 	fmt.Println(query)
 	// Output:
-	// [0 15 40]
+	// [0 20 15 40]
 }
 
 // The following code example demonstrates how to use the Zip
@@ -2506,7 +2506,7 @@ func ExampleQuery_WhereIndexedT() {
 
 	fmt.Println(query)
 	// Output:
-	// [0 15 40]
+	// [0 20 15 40]
 }
 
 // The following code example demonstrates how to use the Zip

--- a/where.go
+++ b/where.go
@@ -55,6 +55,7 @@ func (q Query) WhereIndexed(predicate func(int, interface{}) bool) Query {
 			return func() (item interface{}, ok bool) {
 				for item, ok = next(); ok; item, ok = next() {
 					if predicate(index, item) {
+						index++
 						return
 					}
 

--- a/where_test.go
+++ b/where_test.go
@@ -44,7 +44,6 @@ func TestWhereIndexed(t *testing.T) {
 		{"abcde", func(i int, _ interface{}) bool {
 			return i < 2
 		}, []interface{}{'a', 'b'}},
-
 	}
 
 	for _, test := range tests {

--- a/where_test.go
+++ b/where_test.go
@@ -41,6 +41,10 @@ func TestWhereIndexed(t *testing.T) {
 		{"sstr", func(i int, x interface{}) bool {
 			return x.(rune) != 's' || i == 1
 		}, []interface{}{'s', 't', 'r'}},
+		{"abcde", func(i int, _ interface{}) bool {
+			return i < 2
+		}, []interface{}{'a', 'b'}},
+
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This pr fixes #86 
Reason: `index` wasn't incremented when `predicate` was true