### PR TITLE
Typed channels support

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ From(sentences).
 ## Release Notes
 
 ~~~
+v3.0.2 (2020-02-23)
+* Added FromChannelT().
 
 v3.0.1 (2019-07-09)
 * Support for Go modules

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -61,3 +61,33 @@ func BenchmarkZipSkipTake_generics(b *testing.B) {
 		}).Skip(2).Take(5)
 	}
 }
+
+func BenchmarkFromChannel(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		ch := make(chan interface{})
+		go func() {
+			for i := 0; i < size; i++ {
+				ch <- i
+			}
+
+			close(ch)
+		}()
+
+		FromChannel(ch).All(func(i interface{}) bool { return true })
+	}
+}
+
+func BenchmarkFromTypedChannel(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		ch := make(chan interface{})
+		go func() {
+			for i := 0; i < size; i++ {
+				ch <- i
+			}
+
+			close(ch)
+		}()
+
+		FromTypedChannel(ch).All(func(i interface{}) bool { return true })
+	}
+}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -77,7 +77,7 @@ func BenchmarkFromChannel(b *testing.B) {
 	}
 }
 
-func BenchmarkFromTypedChannel(b *testing.B) {
+func BenchmarkFromChannelT(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		ch := make(chan interface{})
 		go func() {
@@ -88,6 +88,6 @@ func BenchmarkFromTypedChannel(b *testing.B) {
 			close(ch)
 		}()
 
-		FromTypedChannel(ch).All(func(i interface{}) bool { return true })
+		FromChannelT(ch).All(func(i interface{}) bool { return true })
 	}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -2509,7 +2509,7 @@ func ExampleQuery_WhereIndexedT() {
 	// [0 20 15 40]
 }
 
-// The following code example demonstrates how to use the Zip
+// The following code example demonstrates how to use the ZipT
 // method to merge two slices.
 func ExampleQuery_ZipT() {
 	number := []int{1, 2, 3, 4, 5}
@@ -2523,4 +2523,20 @@ func ExampleQuery_ZipT() {
 	fmt.Println(q.Results())
 	// Output:
 	// [[1 one] [2 two] [3 three]]
+}
+
+// The following code example demonstrates how to use the FromChannelT
+// to make a Query from typed channel.
+func ExampleQuery_FromChannelT() {
+	ch := make(chan string, 3)
+	ch <- "one"
+	ch <- "two"
+	ch <- "three"
+	close(ch)
+
+	q := FromChannelT(ch)
+
+	fmt.Println(q.Results())
+	// Output:
+	// [one two three]
 }

--- a/example_test.go
+++ b/example_test.go
@@ -2527,7 +2527,7 @@ func ExampleQuery_ZipT() {
 
 // The following code example demonstrates how to use the FromChannelT
 // to make a Query from typed channel.
-func ExampleQuery_FromChannelT() {
+func ExampleFromChannelT() {
 	ch := make(chan string, 3)
 	ch <- "one"
 	ch <- "two"

--- a/from.go
+++ b/from.go
@@ -81,7 +81,7 @@ func From(source interface{}) Query {
 		if _, ok := source.(chan interface{}); ok {
 			return FromChannel(source.(chan interface{}))
 		} else {
-			return FromTypedChannel(source)
+			return FromChannelT(source)
 		}
 	default:
 		return FromIterable(source.(Iterable))
@@ -101,9 +101,12 @@ func FromChannel(source <-chan interface{}) Query {
 	}
 }
 
-// FromTypedChannel initializes a linq query with passed typed channel, linq iterates over
-// channel until it is closed.
-func FromTypedChannel(source interface{}) Query {
+// FromChannelT is the typed version of FromChannel.
+//
+//   - source is of type "chan TSource"
+//
+// NOTE: FromChannel has better performance than FromChannelT.
+func FromChannelT(source interface{}) Query {
 	src := reflect.ValueOf(source)
 	return Query{
 		Iterate: func() Iterator {

--- a/from_test.go
+++ b/from_test.go
@@ -9,6 +9,12 @@ func TestFrom(t *testing.T) {
 	c <- 1
 	close(c)
 
+	ct := make(chan int, 3)
+	ct <- -10
+	ct <- 0
+	ct <- 10
+	close(ct)
+
 	tests := []struct {
 		input  interface{}
 		output []interface{}
@@ -23,6 +29,7 @@ func TestFrom(t *testing.T) {
 		{map[string]bool{"foo": true}, []interface{}{KeyValue{"foo", true}}, true},
 		{map[string]bool{"foo": true}, []interface{}{KeyValue{"foo", false}}, false},
 		{c, []interface{}{-1, 0, 1}, true},
+		{ct, []interface{}{-10, 0, 10}, true},
 		{foo{f1: 1, f2: true, f3: "string"}, []interface{}{1, true, "string"}, true},
 	}
 
@@ -48,6 +55,20 @@ func TestFromChannel(t *testing.T) {
 
 	if q := FromChannel(c); !validateQuery(q, w) {
 		t.Errorf("FromChannel() failed expected %v", w)
+	}
+}
+
+func TestFromTypedChannel(t *testing.T) {
+	c := make(chan int, 3)
+	c <- 10
+	c <- 15
+	c <- -3
+	close(c)
+
+	w := []interface{}{10, 15, -3}
+
+	if q := FromTypedChannel(c); !validateQuery(q, w) {
+		t.Errorf("FromTypedChannel() failed expected %v", w)
 	}
 }
 

--- a/from_test.go
+++ b/from_test.go
@@ -58,7 +58,7 @@ func TestFromChannel(t *testing.T) {
 	}
 }
 
-func TestFromTypedChannel(t *testing.T) {
+func TestFromChannelT(t *testing.T) {
 	c := make(chan int, 3)
 	c <- 10
 	c <- 15
@@ -67,8 +67,8 @@ func TestFromTypedChannel(t *testing.T) {
 
 	w := []interface{}{10, 15, -3}
 
-	if q := FromTypedChannel(c); !validateQuery(q, w) {
-		t.Errorf("FromTypedChannel() failed expected %v", w)
+	if q := FromChannelT(c); !validateQuery(q, w) {
+		t.Errorf("FromChannelT() failed expected %v", w)
 	}
 }
 


### PR DESCRIPTION
- introduced a new method `FromTypedChannel()`
- `From()` calls `FromChannel()` if channel is of type `chan interface{}` and `FromTypedChannel` for all other channels
- benchmark for `FromTypedChannel()` and `FromChannel()` performance comparison