### PR TITLE
Major Update for go-linq

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 language: go
 go:
-  - 1.11
+  - 1.23
   - tip
 
 install: true

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -5,15 +5,15 @@ import "strings"
 
 func TestAggregate(t *testing.T) {
 	tests := []struct {
-		input interface{}
-		want  interface{}
+		input any
+		want  any
 	}{
 		{[]string{"apple", "mango", "orange", "passionfruit", "grape"}, "passionfruit"},
 		{[]string{}, nil},
 	}
 
 	for _, test := range tests {
-		r := From(test.input).Aggregate(func(r interface{}, i interface{}) interface{} {
+		r := From(test.input).Aggregate(func(r any, i any) any {
 			if len(r.(string)) > len(i.(string)) {
 				return r
 			}
@@ -42,7 +42,7 @@ func TestAggregateWithSeed(t *testing.T) {
 	want := "passionfruit"
 
 	r := From(input).AggregateWithSeed(want,
-		func(r interface{}, i interface{}) interface{} {
+		func(r any, i any) any {
 			if len(r.(string)) > len(i.(string)) {
 				return r
 			}
@@ -70,13 +70,13 @@ func TestAggregateWithSeedBy(t *testing.T) {
 	want := "PASSIONFRUIT"
 
 	r := From(input).AggregateWithSeedBy("banana",
-		func(r interface{}, i interface{}) interface{} {
+		func(r any, i any) any {
 			if len(r.(string)) > len(i.(string)) {
 				return r
 			}
 			return i
 		},
-		func(r interface{}) interface{} {
+		func(r any) any {
 			return strings.ToUpper(r.(string))
 		},
 	)

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -8,9 +8,9 @@ const (
 
 func BenchmarkSelectWhereFirst(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		Range(1, size).Select(func(i interface{}) interface{} {
+		Range(1, size).Select(func(i any) any {
 			return -i.(int)
-		}).Where(func(i interface{}) bool {
+		}).Where(func(i any) bool {
 			return i.(int) > -1000
 		}).First()
 	}
@@ -28,7 +28,7 @@ func BenchmarkSelectWhereFirst_generics(b *testing.B) {
 
 func BenchmarkSum(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		Range(1, size).Where(func(i interface{}) bool {
+		Range(1, size).Where(func(i any) bool {
 			return i.(int)%2 == 0
 		}).SumInts()
 	}
@@ -44,9 +44,9 @@ func BenchmarkSum_generics(b *testing.B) {
 
 func BenchmarkZipSkipTake(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		Range(1, size).Zip(Range(1, size).Select(func(i interface{}) interface{} {
+		Range(1, size).Zip(Range(1, size).Select(func(i any) any {
 			return i.(int) * 2
-		}), func(i, j interface{}) interface{} {
+		}), func(i, j any) any {
 			return i.(int) + j.(int)
 		}).Skip(2).Take(5)
 	}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -61,33 +61,3 @@ func BenchmarkZipSkipTake_generics(b *testing.B) {
 		}).Skip(2).Take(5)
 	}
 }
-
-func BenchmarkFromChannel(b *testing.B) {
-	for n := 0; n < b.N; n++ {
-		ch := make(chan interface{})
-		go func() {
-			for i := 0; i < size; i++ {
-				ch <- i
-			}
-
-			close(ch)
-		}()
-
-		FromChannel(ch).All(func(i interface{}) bool { return true })
-	}
-}
-
-func BenchmarkFromChannelT(b *testing.B) {
-	for n := 0; n < b.N; n++ {
-		ch := make(chan interface{})
-		go func() {
-			for i := 0; i < size; i++ {
-				ch <- i
-			}
-
-			close(ch)
-		}()
-
-		FromChannelT(ch).All(func(i interface{}) bool { return true })
-	}
-}

--- a/compare.go
+++ b/compare.go
@@ -2,21 +2,22 @@ package linq
 
 type comparer func(interface{}, interface{}) int
 
-// Comparable is an interface that has to be implemented by a custom collection
-// elements in order to work with linq.
+// Comparable is an interface that has to be implemented by a custom type
+// to work with linq.
 //
 // Example:
-// 	func (f foo) CompareTo(c Comparable) int {
-// 		a, b := f.f1, c.(foo).f1
 //
-// 		if a < b {
-// 			return -1
-// 		} else if a > b {
-// 			return 1
-// 		}
+//	func (f foo) CompareTo(c Comparable) int {
+//		a, b := f.f1, c.(foo).f1
 //
-// 		return 0
-// 	}
+//		if a < b {
+//			return -1
+//		} else if a > b {
+//			return 1
+//		}
+//
+//		return 0
+//	}
 type Comparable interface {
 	CompareTo(Comparable) int
 }

--- a/compare.go
+++ b/compare.go
@@ -1,6 +1,6 @@
 package linq
 
-type comparer func(interface{}, interface{}) int
+type comparer func(any, any) int
 
 // Comparable is an interface that has to be implemented by a custom type
 // to work with linq.
@@ -22,10 +22,10 @@ type Comparable interface {
 	CompareTo(Comparable) int
 }
 
-func getComparer(data interface{}) comparer {
+func getComparer(data any) comparer {
 	switch data.(type) {
 	case int:
-		return func(x, y interface{}) int {
+		return func(x, y any) int {
 			a, b := x.(int), y.(int)
 			switch {
 			case a > b:
@@ -37,7 +37,7 @@ func getComparer(data interface{}) comparer {
 			}
 		}
 	case int8:
-		return func(x, y interface{}) int {
+		return func(x, y any) int {
 			a, b := x.(int8), y.(int8)
 			switch {
 			case a > b:
@@ -49,7 +49,7 @@ func getComparer(data interface{}) comparer {
 			}
 		}
 	case int16:
-		return func(x, y interface{}) int {
+		return func(x, y any) int {
 			a, b := x.(int16), y.(int16)
 			switch {
 			case a > b:
@@ -61,7 +61,7 @@ func getComparer(data interface{}) comparer {
 			}
 		}
 	case int32:
-		return func(x, y interface{}) int {
+		return func(x, y any) int {
 			a, b := x.(int32), y.(int32)
 			switch {
 			case a > b:
@@ -73,7 +73,7 @@ func getComparer(data interface{}) comparer {
 			}
 		}
 	case int64:
-		return func(x, y interface{}) int {
+		return func(x, y any) int {
 			a, b := x.(int64), y.(int64)
 			switch {
 			case a > b:
@@ -85,7 +85,7 @@ func getComparer(data interface{}) comparer {
 			}
 		}
 	case uint:
-		return func(x, y interface{}) int {
+		return func(x, y any) int {
 			a, b := x.(uint), y.(uint)
 			switch {
 			case a > b:
@@ -97,7 +97,7 @@ func getComparer(data interface{}) comparer {
 			}
 		}
 	case uint8:
-		return func(x, y interface{}) int {
+		return func(x, y any) int {
 			a, b := x.(uint8), y.(uint8)
 			switch {
 			case a > b:
@@ -109,7 +109,7 @@ func getComparer(data interface{}) comparer {
 			}
 		}
 	case uint16:
-		return func(x, y interface{}) int {
+		return func(x, y any) int {
 			a, b := x.(uint16), y.(uint16)
 			switch {
 			case a > b:
@@ -121,7 +121,7 @@ func getComparer(data interface{}) comparer {
 			}
 		}
 	case uint32:
-		return func(x, y interface{}) int {
+		return func(x, y any) int {
 			a, b := x.(uint32), y.(uint32)
 			switch {
 			case a > b:
@@ -133,7 +133,7 @@ func getComparer(data interface{}) comparer {
 			}
 		}
 	case uint64:
-		return func(x, y interface{}) int {
+		return func(x, y any) int {
 			a, b := x.(uint64), y.(uint64)
 			switch {
 			case a > b:
@@ -145,7 +145,7 @@ func getComparer(data interface{}) comparer {
 			}
 		}
 	case float32:
-		return func(x, y interface{}) int {
+		return func(x, y any) int {
 			a, b := x.(float32), y.(float32)
 			switch {
 			case a > b:
@@ -157,7 +157,7 @@ func getComparer(data interface{}) comparer {
 			}
 		}
 	case float64:
-		return func(x, y interface{}) int {
+		return func(x, y any) int {
 			a, b := x.(float64), y.(float64)
 			switch {
 			case a > b:
@@ -169,7 +169,7 @@ func getComparer(data interface{}) comparer {
 			}
 		}
 	case string:
-		return func(x, y interface{}) int {
+		return func(x, y any) int {
 			a, b := x.(string), y.(string)
 			switch {
 			case a > b:
@@ -181,7 +181,7 @@ func getComparer(data interface{}) comparer {
 			}
 		}
 	case bool:
-		return func(x, y interface{}) int {
+		return func(x, y any) int {
 			a, b := x.(bool), y.(bool)
 			switch {
 			case a == b:
@@ -193,7 +193,7 @@ func getComparer(data interface{}) comparer {
 			}
 		}
 	default:
-		return func(x, y interface{}) int {
+		return func(x, y any) int {
 			a, b := x.(Comparable), y.(Comparable)
 			return a.CompareTo(b)
 		}

--- a/compare_test.go
+++ b/compare_test.go
@@ -4,8 +4,8 @@ import "testing"
 
 func TestGetComparer(t *testing.T) {
 	tests := []struct {
-		x    interface{}
-		y    interface{}
+		x    any
+		y    any
 		want int
 	}{
 		{100, 500, -1},

--- a/concat_test.go
+++ b/concat_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestAppend(t *testing.T) {
 	input := []int{1, 2, 3, 4}
-	want := []interface{}{1, 2, 3, 4, 5}
+	want := []any{1, 2, 3, 4, 5}
 
 	if q := From(input).Append(5); !validateQuery(q, want) {
 		t.Errorf("From(%v).Append()=%v expected %v", input, toSlice(q), want)
@@ -14,7 +14,7 @@ func TestAppend(t *testing.T) {
 func TestConcat(t *testing.T) {
 	input1 := []int{1, 2, 3}
 	input2 := []int{4, 5}
-	want := []interface{}{1, 2, 3, 4, 5}
+	want := []any{1, 2, 3, 4, 5}
 
 	if q := From(input1).Concat(From(input2)); !validateQuery(q, want) {
 		t.Errorf("From(%v).Concat(%v)=%v expected %v", input1, input2, toSlice(q), want)
@@ -23,7 +23,7 @@ func TestConcat(t *testing.T) {
 
 func TestPrepend(t *testing.T) {
 	input := []int{1, 2, 3, 4}
-	want := []interface{}{0, 1, 2, 3, 4}
+	want := []any{0, 1, 2, 3, 4}
 
 	if q := From(input).Prepend(0); !validateQuery(q, want) {
 		t.Errorf("From(%v).Prepend()=%v expected %v", input, toSlice(q), want)

--- a/convert.go
+++ b/convert.go
@@ -4,19 +4,19 @@ type intConverter func(interface{}) int64
 
 func getIntConverter(data interface{}) intConverter {
 	switch data.(type) {
-	case (int):
+	case int:
 		return func(i interface{}) int64 {
 			return int64(i.(int))
 		}
-	case (int8):
+	case int8:
 		return func(i interface{}) int64 {
 			return int64(i.(int8))
 		}
-	case (int16):
+	case int16:
 		return func(i interface{}) int64 {
 			return int64(i.(int16))
 		}
-	case (int32):
+	case int32:
 		return func(i interface{}) int64 {
 			return int64(i.(int32))
 		}
@@ -31,19 +31,19 @@ type uintConverter func(interface{}) uint64
 
 func getUIntConverter(data interface{}) uintConverter {
 	switch data.(type) {
-	case (uint):
+	case uint:
 		return func(i interface{}) uint64 {
 			return uint64(i.(uint))
 		}
-	case (uint8):
+	case uint8:
 		return func(i interface{}) uint64 {
 			return uint64(i.(uint8))
 		}
-	case (uint16):
+	case uint16:
 		return func(i interface{}) uint64 {
 			return uint64(i.(uint16))
 		}
-	case (uint32):
+	case uint32:
 		return func(i interface{}) uint64 {
 			return uint64(i.(uint32))
 		}
@@ -58,7 +58,7 @@ type floatConverter func(interface{}) float64
 
 func getFloatConverter(data interface{}) floatConverter {
 	switch data.(type) {
-	case (float32):
+	case float32:
 		return func(i interface{}) float64 {
 			return float64(i.(float32))
 		}

--- a/convert.go
+++ b/convert.go
@@ -1,70 +1,70 @@
 package linq
 
-type intConverter func(interface{}) int64
+type intConverter func(any) int64
 
-func getIntConverter(data interface{}) intConverter {
+func getIntConverter(data any) intConverter {
 	switch data.(type) {
 	case int:
-		return func(i interface{}) int64 {
+		return func(i any) int64 {
 			return int64(i.(int))
 		}
 	case int8:
-		return func(i interface{}) int64 {
+		return func(i any) int64 {
 			return int64(i.(int8))
 		}
 	case int16:
-		return func(i interface{}) int64 {
+		return func(i any) int64 {
 			return int64(i.(int16))
 		}
 	case int32:
-		return func(i interface{}) int64 {
+		return func(i any) int64 {
 			return int64(i.(int32))
 		}
 	}
 
-	return func(i interface{}) int64 {
+	return func(i any) int64 {
 		return i.(int64)
 	}
 }
 
-type uintConverter func(interface{}) uint64
+type uintConverter func(any) uint64
 
-func getUIntConverter(data interface{}) uintConverter {
+func getUIntConverter(data any) uintConverter {
 	switch data.(type) {
 	case uint:
-		return func(i interface{}) uint64 {
+		return func(i any) uint64 {
 			return uint64(i.(uint))
 		}
 	case uint8:
-		return func(i interface{}) uint64 {
+		return func(i any) uint64 {
 			return uint64(i.(uint8))
 		}
 	case uint16:
-		return func(i interface{}) uint64 {
+		return func(i any) uint64 {
 			return uint64(i.(uint16))
 		}
 	case uint32:
-		return func(i interface{}) uint64 {
+		return func(i any) uint64 {
 			return uint64(i.(uint32))
 		}
 	}
 
-	return func(i interface{}) uint64 {
+	return func(i any) uint64 {
 		return i.(uint64)
 	}
 }
 
-type floatConverter func(interface{}) float64
+type floatConverter func(any) float64
 
-func getFloatConverter(data interface{}) floatConverter {
+func getFloatConverter(data any) floatConverter {
 	switch data.(type) {
 	case float32:
-		return func(i interface{}) float64 {
+		return func(i any) float64 {
 			return float64(i.(float32))
 		}
 	}
 
-	return func(i interface{}) float64 {
+	return func(i any) float64 {
 		return i.(float64)
 	}
 }

--- a/convert_test.go
+++ b/convert_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestIntConverter(t *testing.T) {
 	tests := []struct {
-		input interface{}
+		input any
 		want  int64
 	}{
 		{2, 2},
@@ -23,7 +23,7 @@ func TestIntConverter(t *testing.T) {
 
 func TestUIntConverter(t *testing.T) {
 	tests := []struct {
-		input interface{}
+		input any
 		want  uint64
 	}{
 		{uint(2), 2},
@@ -42,7 +42,7 @@ func TestUIntConverter(t *testing.T) {
 
 func TestFloatConverter(t *testing.T) {
 	tests := []struct {
-		input interface{}
+		input any
 		want  float64
 	}{
 		{float32(-1), -1},

--- a/defaultifempty_test.go
+++ b/defaultifempty_test.go
@@ -7,11 +7,11 @@ import (
 func TestDefaultIfEmpty(t *testing.T) {
 	defaultValue := 0
 	tests := []struct {
-		input []interface{}
-		want  []interface{}
+		input []any
+		want  []any
 	}{
-		{[]interface{}{}, []interface{}{defaultValue}},
-		{[]interface{}{1, 2, 3, 4, 5}, []interface{}{1, 2, 3, 4, 5}},
+		{[]any{}, []any{defaultValue}},
+		{[]any{1, 2, 3, 4, 5}, []any{1, 2, 3, 4, 5}},
 	}
 
 	for _, test := range tests {

--- a/distinct_test.go
+++ b/distinct_test.go
@@ -4,12 +4,12 @@ import "testing"
 
 func TestDistinct(t *testing.T) {
 	tests := []struct {
-		input  interface{}
-		output []interface{}
+		input  any
+		output []any
 	}{
-		{[]int{1, 2, 2, 3, 1}, []interface{}{1, 2, 3}},
-		{[9]int{1, 1, 1, 2, 1, 2, 3, 4, 2}, []interface{}{1, 2, 3, 4}},
-		{"sstr", []interface{}{'s', 't', 'r'}},
+		{[]int{1, 2, 2, 3, 1}, []any{1, 2, 3}},
+		{[9]int{1, 1, 1, 2, 1, 2, 3, 4, 2}, []any{1, 2, 3, 4}},
+		{"sstr", []any{'s', 't', 'r'}},
 	}
 
 	for _, test := range tests {
@@ -21,16 +21,16 @@ func TestDistinct(t *testing.T) {
 
 func TestDistinctForOrderedQuery(t *testing.T) {
 	tests := []struct {
-		input  interface{}
-		output []interface{}
+		input  any
+		output []any
 	}{
-		{[]int{1, 2, 2, 3, 1}, []interface{}{1, 2, 3}},
-		{[9]int{1, 1, 1, 2, 1, 2, 3, 4, 2}, []interface{}{1, 2, 3, 4}},
-		{"sstr", []interface{}{'r', 's', 't'}},
+		{[]int{1, 2, 2, 3, 1}, []any{1, 2, 3}},
+		{[9]int{1, 1, 1, 2, 1, 2, 3, 4, 2}, []any{1, 2, 3, 4}},
+		{"sstr", []any{'r', 's', 't'}},
 	}
 
 	for _, test := range tests {
-		if q := From(test.input).OrderBy(func(i interface{}) interface{} {
+		if q := From(test.input).OrderBy(func(i any) any {
 			return i
 		}).Distinct(); !validateQuery(q.Query, test.output) {
 			t.Errorf("From(%v).Distinct()=%v expected %v", test.input, toSlice(q.Query), test.output)
@@ -45,9 +45,9 @@ func TestDistinctBy(t *testing.T) {
 	}
 
 	users := []user{{1, "Foo"}, {2, "Bar"}, {3, "Foo"}}
-	want := []interface{}{user{1, "Foo"}, user{2, "Bar"}}
+	want := []any{user{1, "Foo"}, user{2, "Bar"}}
 
-	if q := From(users).DistinctBy(func(u interface{}) interface{} {
+	if q := From(users).DistinctBy(func(u any) any {
 		return u.(user).name
 	}); !validateQuery(q, want) {
 		t.Errorf("From(%v).DistinctBy()=%v expected %v", users, toSlice(q), want)

--- a/example_test.go
+++ b/example_test.go
@@ -81,8 +81,7 @@ func ExampleQuery() {
 		return i.(int) <= 3
 	})
 
-	next := query.Iterate()
-	for item, ok := next(); ok; item, ok = next() {
+	for item := range query.Iterate {
 		fmt.Println(item)
 	}
 	// Output:
@@ -326,8 +325,8 @@ func ExampleQuery_Append() {
 	// 5
 }
 
-//The following code example demonstrates how to use Average
-//to calculate the average of a slice of values.
+// The following code example demonstrates how to use Average
+// to calculate the average of a slice of values.
 func ExampleQuery_Average() {
 	grades := []int{78, 92, 100, 37, 81}
 	average := From(grades).Average()
@@ -360,8 +359,8 @@ func ExampleQuery_Contains() {
 	// Does the slice contains 5? true
 }
 
-//The following code example demonstrates how to use CountWith
-//to count the even numbers in an array.
+// The following code example demonstrates how to use CountWith
+// to count the even numbers in an array.
 func ExampleQuery_CountWith() {
 	slice := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
@@ -445,8 +444,8 @@ func ExampleQuery_DefaultIfEmpty() {
 
 }
 
-//The following code example demonstrates how to use Distinct
-//to return distinct elements from a slice of integers.
+// The following code example demonstrates how to use Distinct
+// to return distinct elements from a slice of integers.
 func ExampleQuery_Distinct() {
 	ages := []int{21, 46, 46, 55, 17, 21, 55, 55}
 
@@ -567,7 +566,7 @@ func ExampleQuery_First() {
 
 }
 
-//The following code example demonstrates how to use FirstWith
+// The following code example demonstrates how to use FirstWith
 // to return the first element of an array that satisfies a condition.
 func ExampleQuery_FirstWith() {
 	numbers := []int{9, 34, 65, 92, 87, 435, 3, 54, 83, 23, 87, 435, 67, 12, 19}
@@ -583,8 +582,8 @@ func ExampleQuery_FirstWith() {
 
 }
 
-//The following code example demonstrates how to use Intersect
-//to return the elements that appear in each of two slices of integers.
+// The following code example demonstrates how to use Intersect
+// to return the elements that appear in each of two slices of integers.
 func ExampleQuery_Intersect() {
 	id1 := []int{44, 26, 92, 30, 71, 38}
 	id2 := []int{39, 59, 83, 47, 26, 4, 30}
@@ -603,8 +602,8 @@ func ExampleQuery_Intersect() {
 
 }
 
-//The following code example demonstrates how to use IntersectBy
-//to return the elements that appear in each of two slices of products with same Code.
+// The following code example demonstrates how to use IntersectBy
+// to return the elements that appear in each of two slices of products with same Code.
 func ExampleQuery_IntersectBy() {
 	type Product struct {
 		Name string
@@ -716,10 +715,10 @@ func ExampleQuery_OrderByDescending() {
 // The following code example demonstrates how to use ThenByDescending to perform
 // a secondary ordering of the elements in a slice in descending order.
 func ExampleOrderedQuery_ThenByDescending() {
-	fruits := []string{"apPLe", "baNanA", "apple", "APple", "orange", "BAnana", "ORANGE", "apPLE"}
+	fruits := []string{"apPLe", "baNanA", "apple", "APple", "orange", "BAnana", "ORANGE"}
 
 	// Sort the strings first ascending by their length and
-	// then descending using a custom case insensitive comparer.
+	// then descending using a custom case-insensitive comparer.
 	var query []string
 	From(fruits).
 		OrderBy(
@@ -728,21 +727,22 @@ func ExampleOrderedQuery_ThenByDescending() {
 		ThenByDescending(
 			func(fruit interface{}) interface{} { return fruit.(string)[0] },
 		).
+		ThenByDescending(
+			func(fruit interface{}) interface{} { return fruit.(string)[3] },
+		).
 		ToSlice(&query)
 
 	for _, fruit := range query {
 		fmt.Println(fruit)
 	}
 	// Output:
-	// apPLe
-	// apPLE
 	// apple
+	// apPLe
 	// APple
 	// orange
 	// baNanA
 	// ORANGE
 	// BAnana
-
 }
 
 // The following code example demonstrates how to use Concat
@@ -1281,7 +1281,8 @@ func ExampleQuery_SumUInts() {
 }
 
 // The following code example demonstrates how to use Take
-//  to return elements from the start of a slice.
+//
+//	to return elements from the start of a slice.
 func ExampleQuery_Take() {
 	grades := []int{59, 82, 70, 56, 92, 98, 85}
 
@@ -1910,7 +1911,8 @@ func ExampleQuery_GroupByT() {
 }
 
 // The following code example demonstrates how to use GroupJoinT
-//  to perform a grouped join on two slices.
+//
+//	to perform a grouped join on two slices.
 func ExampleQuery_GroupJoinT() {
 
 	type Person struct {
@@ -2405,7 +2407,7 @@ func ExampleQuery_SelectManyByIndexedT() {
 
 }
 
-//The following code example demonstrates how to use SingleWithT
+// The following code example demonstrates how to use SingleWithT
 // to select the only element of a slice that satisfies a condition.
 func ExampleQuery_SingleWithT() {
 	fruits := []string{"apple", "banana", "mango", "orange", "passionfruit", "grape"}
@@ -2610,16 +2612,16 @@ func ExampleQuery_ZipT() {
 	// [[1 one] [2 two] [3 three]]
 }
 
-// The following code example demonstrates how to use the FromChannelT
-// to make a Query from typed channel.
-func ExampleFromChannelT() {
+// The following code example demonstrates how to use the FromChannel
+// to make a Query from a typed channel.
+func ExampleFromChannel() {
 	ch := make(chan string, 3)
 	ch <- "one"
 	ch <- "two"
 	ch <- "three"
 	close(ch)
 
-	q := FromChannelT(ch)
+	q := FromChannel(ch)
 
 	fmt.Println(q.Results())
 	// Output:

--- a/example_test.go
+++ b/example_test.go
@@ -77,7 +77,7 @@ func ExampleRepeat() {
 }
 
 func ExampleQuery() {
-	query := From([]int{1, 2, 3, 4, 5}).Where(func(i interface{}) bool {
+	query := From([]int{1, 2, 3, 4, 5}).Where(func(i any) bool {
 		return i.(int) <= 3
 	})
 
@@ -97,7 +97,7 @@ func ExampleQuery_Aggregate() {
 	// Determine which string in the slice is the longest.
 	longestName := From(fruits).
 		Aggregate(
-			func(r interface{}, i interface{}) interface{} {
+			func(r any, i any) any {
 				if len(r.(string)) > len(i.(string)) {
 					return r
 				}
@@ -117,7 +117,7 @@ func ExampleQuery_AggregateWithSeed() {
 	// Count the even numbers in the array, using a seed value of 0.
 	numEven := From(ints).
 		AggregateWithSeed(0,
-			func(total, next interface{}) interface{} {
+			func(total, next any) any {
 				if next.(int)%2 == 0 {
 					return total.(int) + 1
 				}
@@ -137,7 +137,7 @@ func ExampleQuery_AggregateWithSeedBy() {
 	// Determine whether any string in the array is longer than "banana".
 	longestName := From(input).
 		AggregateWithSeedBy("banana",
-			func(longest interface{}, next interface{}) interface{} {
+			func(longest any, next any) any {
 				if len(longest.(string)) > len(next.(string)) {
 					return longest
 				}
@@ -145,7 +145,7 @@ func ExampleQuery_AggregateWithSeedBy() {
 
 			},
 			// Return the final result
-			func(result interface{}) interface{} {
+			func(result any) any {
 				return fmt.Sprintf("The fruit with the longest name is %s.", result)
 			},
 		)
@@ -163,7 +163,7 @@ func ExampleOrderedQuery_Distinct() {
 	var distinctAges []int
 	From(ages).
 		OrderBy(
-			func(item interface{}) interface{} { return item },
+			func(item any) any { return item },
 		).
 		Distinct().
 		ToSlice(&distinctAges)
@@ -192,10 +192,10 @@ func ExampleOrderedQuery_DistinctBy() {
 	var noduplicates []Product
 	From(products).
 		OrderBy(
-			func(item interface{}) interface{} { return item.(Product).Name },
+			func(item any) any { return item.(Product).Name },
 		).
 		DistinctBy(
-			func(item interface{}) interface{} { return item.(Product).Code },
+			func(item any) any { return item.(Product).Code },
 		).
 		ToSlice(&noduplicates)
 
@@ -218,10 +218,10 @@ func ExampleOrderedQuery_ThenBy() {
 	var query []string
 	From(fruits).
 		OrderBy(
-			func(fruit interface{}) interface{} { return len(fruit.(string)) },
+			func(fruit any) any { return len(fruit.(string)) },
 		).
 		ThenBy(
-			func(fruit interface{}) interface{} { return fruit },
+			func(fruit any) any { return fruit },
 		).
 		ToSlice(&query)
 
@@ -260,7 +260,7 @@ func ExampleQuery_All() {
 	// in the array start with 'B'.
 	allStartWithB := From(pets).
 		All(
-			func(pet interface{}) bool { return strings.HasPrefix(pet.(Pet).Name, "B") },
+			func(pet any) bool { return strings.HasPrefix(pet.(Pet).Name, "B") },
 		)
 
 	fmt.Printf("All pet names start with 'B'? %t", allStartWithB)
@@ -300,7 +300,7 @@ func ExampleQuery_AnyWith() {
 	// Determine whether any pets over age 1 are also unvaccinated.
 	unvaccinated := From(pets).
 		AnyWith(
-			func(p interface{}) bool {
+			func(p any) bool {
 				return p.(Pet).Age > 1 && p.(Pet).Vaccinated == false
 			},
 		)
@@ -366,7 +366,7 @@ func ExampleQuery_CountWith() {
 
 	evenCount := From(slice).
 		CountWith(
-			func(item interface{}) bool { return item.(int)%2 == 0 },
+			func(item any) bool { return item.(int)%2 == 0 },
 		)
 
 	fmt.Println(evenCount)
@@ -478,7 +478,7 @@ func ExampleQuery_DistinctBy() {
 	var noduplicates []Product
 	From(products).
 		DistinctBy(
-			func(item interface{}) interface{} { return item.(Product).Code },
+			func(item any) any { return item.(Product).Code },
 		).
 		ToSlice(&noduplicates)
 
@@ -540,7 +540,7 @@ func ExampleQuery_ExceptBy() {
 	var except []Product
 	From(fruits1).
 		ExceptBy(From(fruits2),
-			func(item interface{}) interface{} { return item.(Product).Code },
+			func(item any) any { return item.(Product).Code },
 		).
 		ToSlice(&except)
 
@@ -573,7 +573,7 @@ func ExampleQuery_FirstWith() {
 
 	first := From(numbers).
 		FirstWith(
-			func(item interface{}) bool { return item.(int) > 80 },
+			func(item any) bool { return item.(int) > 80 },
 		)
 
 	fmt.Println(first)
@@ -623,7 +623,7 @@ func ExampleQuery_IntersectBy() {
 	var duplicates []Product
 	From(store1).
 		IntersectBy(From(store2),
-			func(p interface{}) interface{} { return p.(Product).Code },
+			func(p any) any { return p.(Product).Code },
 		).
 		ToSlice(&duplicates)
 
@@ -658,7 +658,7 @@ func ExampleQuery_LastWith() {
 
 	last := From(numbers).
 		LastWith(
-			func(n interface{}) bool { return n.(int) > 80 },
+			func(n any) bool { return n.(int) > 80 },
 		)
 
 	fmt.Println(last)
@@ -704,7 +704,7 @@ func ExampleQuery_OrderByDescending() {
 	var result []string
 	From(names).
 		OrderByDescending(
-			func(n interface{}) interface{} { return n },
+			func(n any) any { return n },
 		).ToSlice(&result)
 
 	fmt.Println(result)
@@ -722,13 +722,13 @@ func ExampleOrderedQuery_ThenByDescending() {
 	var query []string
 	From(fruits).
 		OrderBy(
-			func(fruit interface{}) interface{} { return len(fruit.(string)) },
+			func(fruit any) any { return len(fruit.(string)) },
 		).
 		ThenByDescending(
-			func(fruit interface{}) interface{} { return fruit.(string)[0] },
+			func(fruit any) any { return fruit.(string)[0] },
 		).
 		ThenByDescending(
-			func(fruit interface{}) interface{} { return fruit.(string)[3] },
+			func(fruit any) any { return fruit.(string)[3] },
 		).
 		ToSlice(&query)
 
@@ -760,10 +760,10 @@ func ExampleQuery_GroupBy() {
 	input := []int{1, 2, 3, 4, 5, 6, 7, 8, 9}
 
 	q := From(input).GroupBy(
-		func(i interface{}) interface{} { return i.(int) % 2 },
-		func(i interface{}) interface{} { return i.(int) })
+		func(i any) any { return i.(int) % 2 },
+		func(i any) any { return i.(int) })
 
-	fmt.Println(q.OrderBy(func(i interface{}) interface{} {
+	fmt.Println(q.OrderBy(func(i any) any {
 		return i.(Group).Key
 	}).Results())
 	// Output:
@@ -783,9 +783,9 @@ func ExampleQuery_GroupJoin() {
 
 	q := FromString("abc").
 		GroupJoin(From(fruits),
-			func(i interface{}) interface{} { return i },
-			func(i interface{}) interface{} { return []rune(i.(string))[0] },
-			func(outer interface{}, inners []interface{}) interface{} {
+			func(i any) any { return i },
+			func(i any) any { return []rune(i.(string))[0] },
+			func(outer any, inners []any) any {
 				return KeyValue{string(outer.(rune)), inners}
 			},
 		)
@@ -822,7 +822,7 @@ func ExampleQuery_IndexOf() {
 		},
 	}
 
-	index := From(items).IndexOf(func(i interface{}) bool {
+	index := From(items).IndexOf(func(i any) bool {
 		item, ok := i.(Item)
 		return ok && item.Name == "Rickster"
 	})
@@ -849,9 +849,9 @@ func ExampleQuery_Join() {
 
 	q := Range(1, 10).
 		Join(From(fruits),
-			func(i interface{}) interface{} { return i },
-			func(i interface{}) interface{} { return len(i.(string)) },
-			func(outer interface{}, inner interface{}) interface{} {
+			func(i any) any { return i },
+			func(i any) any { return len(i.(string)) },
+			func(outer any, inner any) any {
 				return KeyValue{outer, inner}
 			},
 		)
@@ -866,10 +866,10 @@ func ExampleQuery_Join() {
 func ExampleQuery_OrderBy() {
 	q := Range(1, 10).
 		OrderBy(
-			func(i interface{}) interface{} { return i.(int) % 2 },
+			func(i any) any { return i.(int) % 2 },
 		).
 		ThenByDescending(
-			func(i interface{}) interface{} { return i },
+			func(i any) any { return i },
 		)
 
 	fmt.Println(q.Results())
@@ -912,7 +912,7 @@ func ExampleQuery_Select() {
 
 	Range(1, 10).
 		Select(
-			func(x interface{}) interface{} { return x.(int) * x.(int) },
+			func(x any) any { return x.(int) * x.(int) },
 		).
 		ToSlice(&squares)
 
@@ -926,7 +926,7 @@ func ExampleQuery_SelectMany() {
 
 	q := From(input).
 		SelectMany(
-			func(i interface{}) Query { return From(i) },
+			func(i any) Query { return From(i) },
 		)
 
 	fmt.Println(q.Results())
@@ -942,7 +942,7 @@ func ExampleQuery_SelectIndexed() {
 	result := []string{}
 	From(fruits).
 		SelectIndexed(
-			func(index int, fruit interface{}) interface{} { return fruit.(string)[:index] },
+			func(index int, fruit any) any { return fruit.(string)[:index] },
 		).
 		ToSlice(&result)
 
@@ -983,13 +983,13 @@ func ExampleQuery_SelectManyByIndexed() {
 
 	From(people).
 		SelectManyByIndexed(
-			func(index int, person interface{}) Query {
+			func(index int, person any) Query {
 				return From(person.(Person).Pets).
-					Select(func(pet interface{}) interface{} {
+					Select(func(pet any) any {
 						return fmt.Sprintf("%d - %s", index, pet.(Pet).Name)
 					})
 			},
-			func(indexedPet, person interface{}) interface{} {
+			func(indexedPet, person any) any {
 				return fmt.Sprintf("Pet: %s, Owner: %s", indexedPet, person.(Person).Name)
 			},
 		).
@@ -1092,8 +1092,8 @@ func ExampleQuery_SelectManyBy() {
 	var results []string
 	From(people).
 		SelectManyBy(
-			func(person interface{}) Query { return From(person.(Person).Pets) },
-			func(pet, person interface{}) interface{} {
+			func(person any) Query { return From(person.(Person).Pets) },
+			func(pet, person any) any {
 				return fmt.Sprintf("Owner: %s, Pet: %s", person.(Person).Name, pet.(Pet).Name)
 			},
 		).
@@ -1157,7 +1157,7 @@ func ExampleQuery_SingleWith() {
 
 	fruit := From(fruits).
 		SingleWith(
-			func(f interface{}) bool { return len(f.(string)) > 10 },
+			func(f any) bool { return len(f.(string)) > 10 },
 		)
 
 	fmt.Println(fruit)
@@ -1173,7 +1173,7 @@ func ExampleQuery_Skip() {
 	var lowerGrades []int
 	From(grades).
 		OrderByDescending(
-			func(g interface{}) interface{} { return g },
+			func(g any) any { return g },
 		).
 		Skip(3).
 		ToSlice(&lowerGrades)
@@ -1191,10 +1191,10 @@ func ExampleQuery_SkipWhile() {
 	var lowerGrades []int
 	From(grades).
 		OrderByDescending(
-			func(g interface{}) interface{} { return g },
+			func(g any) any { return g },
 		).
 		SkipWhile(
-			func(g interface{}) bool { return g.(int) >= 80 },
+			func(g any) bool { return g.(int) >= 80 },
 		).
 		ToSlice(&lowerGrades)
 
@@ -1213,7 +1213,7 @@ func ExampleQuery_SkipWhileIndexed() {
 	var query []int
 	From(amounts).
 		SkipWhileIndexed(
-			func(index int, amount interface{}) bool { return amount.(int) > index*1000 },
+			func(index int, amount any) bool { return amount.(int) > index*1000 },
 		).
 		ToSlice(&query)
 
@@ -1231,7 +1231,7 @@ func ExampleQuery_Sort() {
 	var query []int
 	From(amounts).
 		Sort(
-			func(i interface{}, j interface{}) bool { return i.(int) < j.(int) },
+			func(i any, j any) bool { return i.(int) < j.(int) },
 		).
 		ToSlice(&query)
 
@@ -1289,7 +1289,7 @@ func ExampleQuery_Take() {
 	var topThreeGrades []int
 	From(grades).
 		OrderByDescending(
-			func(grade interface{}) interface{} { return grade },
+			func(grade any) any { return grade },
 		).
 		Take(3).
 		ToSlice(&topThreeGrades)
@@ -1307,7 +1307,7 @@ func ExampleQuery_TakeWhile() {
 	var query []string
 	From(fruits).
 		TakeWhile(
-			func(fruit interface{}) bool { return fruit.(string) != "orange" },
+			func(fruit any) bool { return fruit.(string) != "orange" },
 		).
 		ToSlice(&query)
 
@@ -1327,7 +1327,7 @@ func ExampleQuery_TakeWhileIndexed() {
 	var query []string
 	From(fruits).
 		TakeWhileIndexed(
-			func(index int, fruit interface{}) bool { return len(fruit.(string)) >= index },
+			func(index int, fruit any) bool { return len(fruit.(string)) >= index },
 		).
 		ToSlice(&query)
 
@@ -1339,7 +1339,7 @@ func ExampleQuery_TakeWhileIndexed() {
 // The following code example demonstrates how to use ToChannel
 // to send a slice to a channel.
 func ExampleQuery_ToChannel() {
-	c := make(chan interface{})
+	c := make(chan any)
 
 	go func() {
 		Repeat(10, 3).ToChannel(c)
@@ -1403,16 +1403,16 @@ func ExampleQuery_ToMap() {
 // The following code example demonstrates how to use ToMapBy
 // by using a key and value selectors to populate a map.
 func ExampleQuery_ToMapBy() {
-	input := [][]interface{}{{1, true}}
+	input := [][]any{{1, true}}
 
 	result := make(map[int]bool)
 	From(input).
 		ToMapBy(&result,
-			func(i interface{}) interface{} {
-				return i.([]interface{})[0]
+			func(i any) any {
+				return i.([]any)[0]
 			},
-			func(i interface{}) interface{} {
-				return i.([]interface{})[1]
+			func(i any) any {
+				return i.([]any)[1]
 			},
 		)
 
@@ -1449,7 +1449,7 @@ func ExampleQuery_Where() {
 	var query []string
 	From(fruits).
 		Where(
-			func(f interface{}) bool { return len(f.(string)) > 6 },
+			func(f any) bool { return len(f.(string)) > 6 },
 		).
 		ToSlice(&query)
 
@@ -1466,7 +1466,7 @@ func ExampleQuery_WhereIndexed() {
 	var query []int
 	From(numbers).
 		WhereIndexed(
-			func(index int, number interface{}) bool { return number.(int) <= index*10 },
+			func(index int, number any) bool { return number.(int) <= index*10 },
 		).
 		ToSlice(&query)
 
@@ -1483,7 +1483,7 @@ func ExampleQuery_Zip() {
 
 	q := From(number).
 		Zip(From(words),
-			func(a interface{}, b interface{}) interface{} { return []interface{}{a, b} },
+			func(a any, b any) any { return []any{a, b} },
 		)
 
 	fmt.Println(q.Results())
@@ -1812,7 +1812,7 @@ func ExampleQuery_FirstWithT() {
 func ExampleQuery_ForEach() {
 	fruits := []string{"orange", "apple", "lemon", "apple"}
 
-	From(fruits).ForEach(func(fruit interface{}) {
+	From(fruits).ForEach(func(fruit any) {
 		fmt.Println(fruit)
 	})
 	// Output:
@@ -1827,7 +1827,7 @@ func ExampleQuery_ForEach() {
 func ExampleQuery_ForEachIndexed() {
 	fruits := []string{"orange", "apple", "lemon", "apple"}
 
-	From(fruits).ForEachIndexed(func(i int, fruit interface{}) {
+	From(fruits).ForEachIndexed(func(i int, fruit any) {
 		fmt.Printf("%d.%s\n", i, fruit)
 	})
 	// Output:
@@ -2228,7 +2228,7 @@ func ExampleQuery_SelectManyByT() {
 	From(people).
 		SelectManyByT(
 			func(person Person) Query { return From(person.Pets) },
-			func(pet Pet, person Person) interface{} {
+			func(pet Pet, person Person) any {
 				return fmt.Sprintf("Owner: %s, Pet: %s", person.Name, pet.Name)
 			},
 		).
@@ -2604,7 +2604,7 @@ func ExampleQuery_ZipT() {
 
 	q := From(number).
 		ZipT(From(words),
-			func(a int, b string) []interface{} { return []interface{}{a, b} },
+			func(a int, b string) []any { return []any{a, b} },
 		)
 
 	fmt.Println(q.Results())

--- a/except_test.go
+++ b/except_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestExcept(t *testing.T) {
 	input1 := []int{1, 2, 3, 4, 5, 1, 2, 5}
 	input2 := []int{1, 2}
-	want := []interface{}{3, 4, 5, 5}
+	want := []any{3, 4, 5, 5}
 
 	if q := From(input1).Except(From(input2)); !validateQuery(q, want) {
 		t.Errorf("From(%v).Except(%v)=%v expected %v", input1, input2, toSlice(q), want)
@@ -15,9 +15,9 @@ func TestExcept(t *testing.T) {
 func TestExceptBy(t *testing.T) {
 	input1 := []int{1, 2, 3, 4, 5, 1, 2, 5}
 	input2 := []int{1}
-	want := []interface{}{2, 4, 2}
+	want := []any{2, 4, 2}
 
-	if q := From(input1).ExceptBy(From(input2), func(i interface{}) interface{} {
+	if q := From(input1).ExceptBy(From(input2), func(i any) any {
 		return i.(int) % 2
 	}); !validateQuery(q, want) {
 		t.Errorf("From(%v).ExceptBy(%v)=%v expected %v", input1, input2, toSlice(q), want)

--- a/from_test.go
+++ b/from_test.go
@@ -2,6 +2,56 @@ package linq
 
 import "testing"
 
+func TestFromSlice(t *testing.T) {
+	s := [3]int{1, 2, 3}
+	w := []interface{}{1, 2, 3}
+
+	if q := FromSlice(s[:]); !validateQuery(q, w) {
+		t.Errorf("FromSlice(%v)!=%v", s, w)
+	}
+}
+
+func TestFromMap(t *testing.T) {
+	s := map[string]bool{"foo": true}
+	w := []interface{}{KeyValue{"foo", true}}
+
+	if q := FromMap(s); !validateQuery(q, w) {
+		t.Errorf("FromMap(%v)!=%v", s, w)
+	}
+}
+
+func TestFromChannel(t *testing.T) {
+	c := make(chan int, 3)
+	c <- 10
+	c <- 15
+	c <- -3
+	close(c)
+
+	w := []interface{}{10, 15, -3}
+
+	if q := FromChannel(c); !validateQuery(q, w) {
+		t.Errorf("FromChannel() failed expected %v", w)
+	}
+}
+
+func TestFromString(t *testing.T) {
+	s := "string"
+	w := []interface{}{'s', 't', 'r', 'i', 'n', 'g'}
+
+	if q := FromString(s); !validateQuery(q, w) {
+		t.Errorf("FromString(%v)!=%v", s, w)
+	}
+}
+
+func TestFromIterable(t *testing.T) {
+	s := foo{f1: 1, f2: true, f3: "string"}
+	w := []interface{}{1, true, "string"}
+
+	if q := FromIterable(s); !validateQuery(q, w) {
+		t.Errorf("FromIterable(%v)!=%v", s, w)
+	}
+}
+
 func TestFrom(t *testing.T) {
 	c := make(chan interface{}, 3)
 	c <- -1
@@ -41,52 +91,6 @@ func TestFrom(t *testing.T) {
 				t.Errorf("From(%v)=%v expected not equal", test.input, test.output)
 			}
 		}
-	}
-}
-
-func TestFromChannel(t *testing.T) {
-	c := make(chan interface{}, 3)
-	c <- 10
-	c <- 15
-	c <- -3
-	close(c)
-
-	w := []interface{}{10, 15, -3}
-
-	if q := FromChannel(c); !validateQuery(q, w) {
-		t.Errorf("FromChannel() failed expected %v", w)
-	}
-}
-
-func TestFromChannelT(t *testing.T) {
-	c := make(chan int, 3)
-	c <- 10
-	c <- 15
-	c <- -3
-	close(c)
-
-	w := []interface{}{10, 15, -3}
-
-	if q := FromChannelT(c); !validateQuery(q, w) {
-		t.Errorf("FromChannelT() failed expected %v", w)
-	}
-}
-
-func TestFromString(t *testing.T) {
-	s := "string"
-	w := []interface{}{'s', 't', 'r', 'i', 'n', 'g'}
-
-	if q := FromString(s); !validateQuery(q, w) {
-		t.Errorf("FromString(%v)!=%v", s, w)
-	}
-}
-
-func TestFromIterable(t *testing.T) {
-	s := foo{f1: 1, f2: true, f3: "string"}
-	w := []interface{}{1, true, "string"}
-
-	if q := FromIterable(s); !validateQuery(q, w) {
-		t.Errorf("FromIterable(%v)!=%v", s, w)
 	}
 }
 

--- a/from_test.go
+++ b/from_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestFromSlice(t *testing.T) {
 	s := [3]int{1, 2, 3}
-	w := []interface{}{1, 2, 3}
+	w := []any{1, 2, 3}
 
 	if q := FromSlice(s[:]); !validateQuery(q, w) {
 		t.Errorf("FromSlice(%v)!=%v", s, w)
@@ -13,7 +13,7 @@ func TestFromSlice(t *testing.T) {
 
 func TestFromMap(t *testing.T) {
 	s := map[string]bool{"foo": true}
-	w := []interface{}{KeyValue{"foo", true}}
+	w := []any{KeyValue{"foo", true}}
 
 	if q := FromMap(s); !validateQuery(q, w) {
 		t.Errorf("FromMap(%v)!=%v", s, w)
@@ -27,7 +27,7 @@ func TestFromChannel(t *testing.T) {
 	c <- -3
 	close(c)
 
-	w := []interface{}{10, 15, -3}
+	w := []any{10, 15, -3}
 
 	if q := FromChannel(c); !validateQuery(q, w) {
 		t.Errorf("FromChannel() failed expected %v", w)
@@ -36,7 +36,7 @@ func TestFromChannel(t *testing.T) {
 
 func TestFromString(t *testing.T) {
 	s := "string"
-	w := []interface{}{'s', 't', 'r', 'i', 'n', 'g'}
+	w := []any{'s', 't', 'r', 'i', 'n', 'g'}
 
 	if q := FromString(s); !validateQuery(q, w) {
 		t.Errorf("FromString(%v)!=%v", s, w)
@@ -45,7 +45,7 @@ func TestFromString(t *testing.T) {
 
 func TestFromIterable(t *testing.T) {
 	s := foo{f1: 1, f2: true, f3: "string"}
-	w := []interface{}{1, true, "string"}
+	w := []any{1, true, "string"}
 
 	if q := FromIterable(s); !validateQuery(q, w) {
 		t.Errorf("FromIterable(%v)!=%v", s, w)
@@ -53,7 +53,7 @@ func TestFromIterable(t *testing.T) {
 }
 
 func TestFrom(t *testing.T) {
-	c := make(chan interface{}, 3)
+	c := make(chan any, 3)
 	c <- -1
 	c <- 0
 	c <- 1
@@ -66,21 +66,21 @@ func TestFrom(t *testing.T) {
 	close(ct)
 
 	tests := []struct {
-		input  interface{}
-		output []interface{}
+		input  any
+		output []any
 		want   bool
 	}{
-		{[]int{1, 2, 3}, []interface{}{1, 2, 3}, true},
-		{[]int{1, 2, 4}, []interface{}{1, 2, 3}, false},
-		{[3]int{1, 2, 3}, []interface{}{1, 2, 3}, true},
-		{[3]int{1, 2, 4}, []interface{}{1, 2, 3}, false},
-		{"str", []interface{}{'s', 't', 'r'}, true},
-		{"str", []interface{}{'s', 't', 'g'}, false},
-		{map[string]bool{"foo": true}, []interface{}{KeyValue{"foo", true}}, true},
-		{map[string]bool{"foo": true}, []interface{}{KeyValue{"foo", false}}, false},
-		{c, []interface{}{-1, 0, 1}, true},
-		{ct, []interface{}{-10, 0, 10}, true},
-		{foo{f1: 1, f2: true, f3: "string"}, []interface{}{1, true, "string"}, true},
+		{[]int{1, 2, 3}, []any{1, 2, 3}, true},
+		{[]int{1, 2, 4}, []any{1, 2, 3}, false},
+		{[3]int{1, 2, 3}, []any{1, 2, 3}, true},
+		{[3]int{1, 2, 4}, []any{1, 2, 3}, false},
+		{"str", []any{'s', 't', 'r'}, true},
+		{"str", []any{'s', 't', 'g'}, false},
+		{map[string]bool{"foo": true}, []any{KeyValue{"foo", true}}, true},
+		{map[string]bool{"foo": true}, []any{KeyValue{"foo", false}}, false},
+		{c, []any{-1, 0, 1}, true},
+		{ct, []any{-10, 0, 10}, true},
+		{foo{f1: 1, f2: true, f3: "string"}, []any{1, true, "string"}, true},
 	}
 
 	for _, test := range tests {
@@ -95,7 +95,7 @@ func TestFrom(t *testing.T) {
 }
 
 func TestRange(t *testing.T) {
-	w := []interface{}{-2, -1, 0, 1, 2}
+	w := []any{-2, -1, 0, 1, 2}
 
 	if q := Range(-2, 5); !validateQuery(q, w) {
 		t.Errorf("Range(-2, 5)=%v expected %v", toSlice(q), w)
@@ -103,7 +103,7 @@ func TestRange(t *testing.T) {
 }
 
 func TestRepeat(t *testing.T) {
-	w := []interface{}{1, 1, 1, 1, 1}
+	w := []any{1, 1, 1, 1, 1}
 
 	if q := Repeat(1, 5); !validateQuery(q, w) {
 		t.Errorf("Repeat(1, 5)=%v expected %v", toSlice(q), w)

--- a/general_test.go
+++ b/general_test.go
@@ -8,8 +8,8 @@ import (
 func TestChannelToChannel(t *testing.T) {
 	input := []int{30, 40, 50}
 
-	inpCh := make(chan interface{})
-	resCh := make(chan interface{})
+	inpCh := make(chan any)
+	resCh := make(chan any)
 
 	go func() {
 		for _, i := range input {
@@ -20,7 +20,7 @@ func TestChannelToChannel(t *testing.T) {
 	}()
 
 	go func() {
-		FromChannel(inpCh).Where(func(i interface{}) bool {
+		FromChannel(inpCh).Where(func(i any) bool {
 			return i.(int) > 20
 		}).ToChannel(resCh)
 	}()

--- a/genericfunc.go
+++ b/genericfunc.go
@@ -27,7 +27,7 @@ type genericFunc struct {
 }
 
 // Call calls a dynamic function.
-func (g *genericFunc) Call(params ...interface{}) interface{} {
+func (g *genericFunc) Call(params ...any) any {
 	paramsIn := make([]reflect.Value, len(params))
 	for i, param := range params {
 		paramsIn[i] = reflect.ValueOf(param)
@@ -40,7 +40,7 @@ func (g *genericFunc) Call(params ...interface{}) interface{} {
 }
 
 // newGenericFunc instantiates a new genericFunc pointer
-func newGenericFunc(methodName, paramName string, fn interface{}, validateFunc func(*functionCache) error) (*genericFunc, error) {
+func newGenericFunc(methodName, paramName string, fn any, validateFunc func(*functionCache) error) (*genericFunc, error) {
 	cache := &functionCache{}
 	cache.FnValue = reflect.ValueOf(fn)
 
@@ -104,7 +104,7 @@ func simpleParamValidator(In []reflect.Type, Out []reflect.Type) func(cache *fun
 }
 
 // newElemTypeSlice creates a slice of items elem types.
-func newElemTypeSlice(items ...interface{}) []reflect.Type {
+func newElemTypeSlice(items ...any) []reflect.Type {
 	typeList := make([]reflect.Type, len(items))
 	for i, item := range items {
 		typeItem := reflect.TypeOf(item)

--- a/genericfunc_test.go
+++ b/genericfunc_test.go
@@ -10,7 +10,7 @@ func TestNewGenericFunc(t *testing.T) {
 	tests := []struct {
 		methodName     string
 		paramName      string
-		function       interface{}
+		function       any
 		validationFunc func(*functionCache) error
 		exception      error
 	}{
@@ -76,10 +76,10 @@ func TestCall(t *testing.T) {
 	tests := []struct {
 		methodName     string
 		paramName      string
-		function       interface{}
+		function       any
 		validationFunc func(*functionCache) error
-		fnParameter    interface{}
-		result         interface{}
+		fnParameter    any
+		result         any
 		exception      error
 	}{
 		{ // A valid function and parameters

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/ahmetb/go-linq/v3
+module github.com/ahmetb/go-linq/v4
 
-go 1.11
+go 1.23

--- a/groupby_test.go
+++ b/groupby_test.go
@@ -15,9 +15,8 @@ func TestGroupBy(t *testing.T) {
 		func(i interface{}) interface{} { return i.(int) },
 	)
 
-	next := q.Iterate()
 	eq := true
-	for item, ok := next(); ok; item, ok = next() {
+	for item := range q.Iterate {
 		group := item.(Group)
 		switch group.Key.(int) {
 		case 0:

--- a/groupby_test.go
+++ b/groupby_test.go
@@ -7,12 +7,12 @@ import (
 
 func TestGroupBy(t *testing.T) {
 	input := []int{1, 2, 3, 4, 5, 6, 7, 8, 9}
-	wantEven := []interface{}{2, 4, 6, 8}
-	wantOdd := []interface{}{1, 3, 5, 7, 9}
+	wantEven := []any{2, 4, 6, 8}
+	wantOdd := []any{1, 3, 5, 7, 9}
 
 	q := From(input).GroupBy(
-		func(i interface{}) interface{} { return i.(int) % 2 },
-		func(i interface{}) interface{} { return i.(int) },
+		func(i any) any { return i.(int) % 2 },
+		func(i any) any { return i.(int) },
 	)
 
 	eq := true

--- a/groupjoin_test.go
+++ b/groupjoin_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestGroupJoin(t *testing.T) {
 	outer := []int{0, 1, 2}
 	inner := []int{1, 2, 3, 4, 5, 6, 7, 8, 9}
-	want := []interface{}{
+	want := []any{
 		KeyValue{0, 4},
 		KeyValue{1, 5},
 		KeyValue{2, 0},
@@ -13,9 +13,9 @@ func TestGroupJoin(t *testing.T) {
 
 	q := From(outer).GroupJoin(
 		From(inner),
-		func(i interface{}) interface{} { return i },
-		func(i interface{}) interface{} { return i.(int) % 2 },
-		func(outer interface{}, inners []interface{}) interface{} {
+		func(i any) any { return i },
+		func(i any) any { return i.(int) % 2 },
+		func(outer any, inners []any) any {
 			return KeyValue{outer, len(inners)}
 		})
 

--- a/index.go
+++ b/index.go
@@ -3,11 +3,9 @@ package linq
 // IndexOf searches for an element that matches the conditions defined by a specified predicate
 // and returns the zero-based index of the first occurrence within the collection. This method
 // returns -1 if an item that matches the conditions is not found.
-func (q Query) IndexOf(predicate func(interface{}) bool) int {
+func (q Query) IndexOf(predicate func(any) bool) int {
 	index := 0
-	next := q.Iterate()
-
-	for item, ok := next(); ok; item, ok = next() {
+	for item := range q.Iterate {
 		if predicate(item) {
 			return index
 		}
@@ -22,7 +20,7 @@ func (q Query) IndexOf(predicate func(interface{}) bool) int {
 //   - predicateFn is of type "func(int,TSource)bool"
 //
 // NOTE: IndexOf has better performance than IndexOfT.
-func (q Query) IndexOfT(predicateFn interface{}) int {
+func (q Query) IndexOfT(predicateFn any) int {
 
 	predicateGenericFunc, err := newGenericFunc(
 		"IndexOfT", "predicateFn", predicateFn,
@@ -32,7 +30,7 @@ func (q Query) IndexOfT(predicateFn interface{}) int {
 		panic(err)
 	}
 
-	predicateFunc := func(item interface{}) bool {
+	predicateFunc := func(item any) bool {
 		return predicateGenericFunc.Call(item).(bool)
 	}
 

--- a/index_test.go
+++ b/index_test.go
@@ -6,27 +6,27 @@ import (
 
 func TestIndexOf(t *testing.T) {
 	tests := []struct {
-		input     interface{}
-		predicate func(interface{}) bool
+		input     any
+		predicate func(any) bool
 		expected  int
 	}{
 		{
 			input: [9]int{1, 2, 3, 4, 5, 6, 7, 8, 9},
-			predicate: func(i interface{}) bool {
+			predicate: func(i any) bool {
 				return i.(int) == 3
 			},
 			expected: 2,
 		},
 		{
 			input: "sstr",
-			predicate: func(i interface{}) bool {
+			predicate: func(i any) bool {
 				return i.(rune) == 'r'
 			},
 			expected: 3,
 		},
 		{
 			input: "gadsgsadgsda",
-			predicate: func(i interface{}) bool {
+			predicate: func(i any) bool {
 				return i.(rune) == 'z'
 			},
 			expected: -1,

--- a/intersect_test.go
+++ b/intersect_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestIntersect(t *testing.T) {
 	input1 := []int{1, 2, 3}
 	input2 := []int{1, 4, 7, 9, 12, 3}
-	want := []interface{}{1, 3}
+	want := []any{1, 3}
 
 	if q := From(input1).Intersect(From(input2)); !validateQuery(q, want) {
 		t.Errorf("From(%v).Intersect(%v)=%v expected %v", input1, input2, toSlice(q), want)
@@ -15,9 +15,9 @@ func TestIntersect(t *testing.T) {
 func TestIntersectBy(t *testing.T) {
 	input1 := []int{5, 7, 8}
 	input2 := []int{1, 4, 7, 9, 12, 3}
-	want := []interface{}{5, 8}
+	want := []any{5, 8}
 
-	if q := From(input1).IntersectBy(From(input2), func(i interface{}) interface{} {
+	if q := From(input1).IntersectBy(From(input2), func(i any) any {
 		return i.(int) % 2
 	}); !validateQuery(q, want) {
 		t.Errorf("From(%v).IntersectBy(%v)=%v expected %v", input1, input2, toSlice(q), want)

--- a/join_test.go
+++ b/join_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestJoin(t *testing.T) {
 	outer := []int{0, 1, 2, 3, 4, 5, 8}
 	inner := []int{1, 2, 1, 4, 7, 6, 7, 2}
-	want := []interface{}{
+	want := []any{
 		KeyValue{1, 1},
 		KeyValue{1, 1},
 		KeyValue{2, 2},
@@ -15,9 +15,9 @@ func TestJoin(t *testing.T) {
 
 	q := From(outer).Join(
 		From(inner),
-		func(i interface{}) interface{} { return i },
-		func(i interface{}) interface{} { return i },
-		func(outer interface{}, inner interface{}) interface{} {
+		func(i any) any { return i },
+		func(i any) any { return i },
+		func(outer any, inner any) any {
 			return KeyValue{outer, inner}
 		})
 

--- a/orderby.go
+++ b/orderby.go
@@ -3,7 +3,7 @@ package linq
 import "sort"
 
 type order struct {
-	selector func(interface{}) interface{}
+	selector func(any) any
 	compare  comparer
 	desc     bool
 }
@@ -18,24 +18,19 @@ type OrderedQuery struct {
 
 // OrderBy sorts the elements of a collection in ascending order. Elements are
 // sorted according to a key.
-func (q Query) OrderBy(selector func(interface{}) interface{}) OrderedQuery {
+func (q Query) OrderBy(selector func(any) any) OrderedQuery {
 	return OrderedQuery{
 		orders:   []order{{selector: selector}},
 		original: q,
 		Query: Query{
-			Iterate: func() Iterator {
-				items := q.sort([]order{{selector: selector}})
-				len := len(items)
-				index := 0
-
-				return func() (item interface{}, ok bool) {
-					ok = index < len
-					if ok {
-						item = items[index]
-						index++
+			Iterate: func(yield func(any) bool) {
+				{
+					items := q.sort([]order{{selector: selector}})
+					for _, item := range items {
+						if !yield(item) {
+							return
+						}
 					}
-
-					return
 				}
 			},
 		},
@@ -47,7 +42,7 @@ func (q Query) OrderBy(selector func(interface{}) interface{}) OrderedQuery {
 //   - selectorFn is of type "func(TSource) TKey"
 //
 // NOTE: OrderBy has better performance than OrderByT.
-func (q Query) OrderByT(selectorFn interface{}) OrderedQuery {
+func (q Query) OrderByT(selectorFn any) OrderedQuery {
 	selectorGenericFunc, err := newGenericFunc(
 		"OrderByT", "selectorFn", selectorFn,
 		simpleParamValidator(newElemTypeSlice(new(genericType)), newElemTypeSlice(new(genericType))),
@@ -56,7 +51,7 @@ func (q Query) OrderByT(selectorFn interface{}) OrderedQuery {
 		panic(err)
 	}
 
-	selectorFunc := func(item interface{}) interface{} {
+	selectorFunc := func(item any) any {
 		return selectorGenericFunc.Call(item)
 	}
 
@@ -65,24 +60,17 @@ func (q Query) OrderByT(selectorFn interface{}) OrderedQuery {
 
 // OrderByDescending sorts the elements of a collection in descending order.
 // Elements are sorted according to a key.
-func (q Query) OrderByDescending(selector func(interface{}) interface{}) OrderedQuery {
+func (q Query) OrderByDescending(selector func(any) any) OrderedQuery {
 	return OrderedQuery{
 		orders:   []order{{selector: selector, desc: true}},
 		original: q,
 		Query: Query{
-			Iterate: func() Iterator {
+			Iterate: func(yield func(any) bool) {
 				items := q.sort([]order{{selector: selector, desc: true}})
-				len := len(items)
-				index := 0
-
-				return func() (item interface{}, ok bool) {
-					ok = index < len
-					if ok {
-						item = items[index]
-						index++
+				for _, item := range items {
+					if !yield(item) {
+						return
 					}
-
-					return
 				}
 			},
 		},
@@ -91,8 +79,9 @@ func (q Query) OrderByDescending(selector func(interface{}) interface{}) Ordered
 
 // OrderByDescendingT is the typed version of OrderByDescending.
 //   - selectorFn is of type "func(TSource) TKey"
+//
 // NOTE: OrderByDescending has better performance than OrderByDescendingT.
-func (q Query) OrderByDescendingT(selectorFn interface{}) OrderedQuery {
+func (q Query) OrderByDescendingT(selectorFn any) OrderedQuery {
 	selectorGenericFunc, err := newGenericFunc(
 		"OrderByDescendingT", "selectorFn", selectorFn,
 		simpleParamValidator(newElemTypeSlice(new(genericType)), newElemTypeSlice(new(genericType))),
@@ -101,7 +90,7 @@ func (q Query) OrderByDescendingT(selectorFn interface{}) OrderedQuery {
 		panic(err)
 	}
 
-	selectorFunc := func(item interface{}) interface{} {
+	selectorFunc := func(item any) any {
 		return selectorGenericFunc.Call(item)
 	}
 
@@ -112,24 +101,17 @@ func (q Query) OrderByDescendingT(selectorFn interface{}) OrderedQuery {
 // ascending order. This method enables you to specify multiple sort criteria by
 // applying any number of ThenBy or ThenByDescending methods.
 func (oq OrderedQuery) ThenBy(
-	selector func(interface{}) interface{}) OrderedQuery {
+	selector func(any) any) OrderedQuery {
 	return OrderedQuery{
 		orders:   append(oq.orders, order{selector: selector}),
 		original: oq.original,
 		Query: Query{
-			Iterate: func() Iterator {
+			Iterate: func(yield func(any) bool) {
 				items := oq.original.sort(append(oq.orders, order{selector: selector}))
-				len := len(items)
-				index := 0
-
-				return func() (item interface{}, ok bool) {
-					ok = index < len
-					if ok {
-						item = items[index]
-						index++
+				for _, item := range items {
+					if !yield(item) {
+						return
 					}
-
-					return
 				}
 			},
 		},
@@ -138,8 +120,9 @@ func (oq OrderedQuery) ThenBy(
 
 // ThenByT is the typed version of ThenBy.
 //   - selectorFn is of type "func(TSource) TKey"
+//
 // NOTE: ThenBy has better performance than ThenByT.
-func (oq OrderedQuery) ThenByT(selectorFn interface{}) OrderedQuery {
+func (oq OrderedQuery) ThenByT(selectorFn any) OrderedQuery {
 	selectorGenericFunc, err := newGenericFunc(
 		"ThenByT", "selectorFn", selectorFn,
 		simpleParamValidator(newElemTypeSlice(new(genericType)), newElemTypeSlice(new(genericType))),
@@ -148,7 +131,7 @@ func (oq OrderedQuery) ThenByT(selectorFn interface{}) OrderedQuery {
 		panic(err)
 	}
 
-	selectorFunc := func(item interface{}) interface{} {
+	selectorFunc := func(item any) any {
 		return selectorGenericFunc.Call(item)
 	}
 
@@ -158,24 +141,17 @@ func (oq OrderedQuery) ThenByT(selectorFn interface{}) OrderedQuery {
 // ThenByDescending performs a subsequent ordering of the elements in a
 // collection in descending order. This method enables you to specify multiple
 // sort criteria by applying any number of ThenBy or ThenByDescending methods.
-func (oq OrderedQuery) ThenByDescending(selector func(interface{}) interface{}) OrderedQuery {
+func (oq OrderedQuery) ThenByDescending(selector func(any) any) OrderedQuery {
 	return OrderedQuery{
 		orders:   append(oq.orders, order{selector: selector, desc: true}),
 		original: oq.original,
 		Query: Query{
-			Iterate: func() Iterator {
+			Iterate: func(yield func(any) bool) {
 				items := oq.original.sort(append(oq.orders, order{selector: selector, desc: true}))
-				len := len(items)
-				index := 0
-
-				return func() (item interface{}, ok bool) {
-					ok = index < len
-					if ok {
-						item = items[index]
-						index++
+				for _, item := range items {
+					if !yield(item) {
+						return
 					}
-
-					return
 				}
 			},
 		},
@@ -184,9 +160,10 @@ func (oq OrderedQuery) ThenByDescending(selector func(interface{}) interface{}) 
 
 // ThenByDescendingT is the typed version of ThenByDescending.
 //   - selectorFn is of type "func(TSource) TKey"
+//
 // NOTE: ThenByDescending has better performance than ThenByDescendingT.
-func (oq OrderedQuery) ThenByDescendingT(selectorFn interface{}) OrderedQuery {
-	selectorFunc, ok := selectorFn.(func(interface{}) interface{})
+func (oq OrderedQuery) ThenByDescendingT(selectorFn any) OrderedQuery {
+	selectorFunc, ok := selectorFn.(func(any) any)
 	if !ok {
 		selectorGenericFunc, err := newGenericFunc(
 			"ThenByDescending", "selectorFn", selectorFn,
@@ -196,7 +173,7 @@ func (oq OrderedQuery) ThenByDescendingT(selectorFn interface{}) OrderedQuery {
 			panic(err)
 		}
 
-		selectorFunc = func(item interface{}) interface{} {
+		selectorFunc = func(item any) any {
 			return selectorGenericFunc.Call(item)
 		}
 	}
@@ -206,23 +183,16 @@ func (oq OrderedQuery) ThenByDescendingT(selectorFn interface{}) OrderedQuery {
 // Sort returns a new query by sorting elements with provided less function in
 // ascending order. The comparer function should return true if the parameter i
 // is less than j. While this method is uglier than chaining OrderBy,
-// OrderByDescending, ThenBy and ThenByDescending methods, it's performance is
+// OrderByDescending, ThenBy and ThenByDescending methods, its performance is
 // much better.
-func (q Query) Sort(less func(i, j interface{}) bool) Query {
+func (q Query) Sort(less func(i, j any) bool) Query {
 	return Query{
-		Iterate: func() Iterator {
+		Iterate: func(yield func(any) bool) {
 			items := q.lessSort(less)
-			len := len(items)
-			index := 0
-
-			return func() (item interface{}, ok bool) {
-				ok = index < len
-				if ok {
-					item = items[index]
-					index++
+			for _, item := range items {
+				if !yield(item) {
+					return
 				}
-
-				return
 			}
 		},
 	}
@@ -230,8 +200,9 @@ func (q Query) Sort(less func(i, j interface{}) bool) Query {
 
 // SortT is the typed version of Sort.
 //   - lessFn is of type "func(TSource,TSource) bool"
+//
 // NOTE: Sort has better performance than SortT.
-func (q Query) SortT(lessFn interface{}) Query {
+func (q Query) SortT(lessFn any) Query {
 	lessGenericFunc, err := newGenericFunc(
 		"SortT", "lessFn", lessFn,
 		simpleParamValidator(newElemTypeSlice(new(genericType), new(genericType)), newElemTypeSlice(new(bool))),
@@ -240,7 +211,7 @@ func (q Query) SortT(lessFn interface{}) Query {
 		panic(err)
 	}
 
-	lessFunc := func(i, j interface{}) bool {
+	lessFunc := func(i, j any) bool {
 		return lessGenericFunc.Call(i, j).(bool)
 	}
 
@@ -248,8 +219,8 @@ func (q Query) SortT(lessFn interface{}) Query {
 }
 
 type sorter struct {
-	items []interface{}
-	less  func(i, j interface{}) bool
+	items []any
+	less  func(i, j any) bool
 }
 
 func (s sorter) Len() int {
@@ -264,9 +235,8 @@ func (s sorter) Less(i, j int) bool {
 	return s.less(s.items[i], s.items[j])
 }
 
-func (q Query) sort(orders []order) (r []interface{}) {
-	next := q.Iterate()
-	for item, ok := next(); ok; item, ok = next() {
+func (q Query) sort(orders []order) (r []any) {
+	for item := range q.Iterate {
 		r = append(r, item)
 	}
 
@@ -280,7 +250,7 @@ func (q Query) sort(orders []order) (r []interface{}) {
 
 	s := sorter{
 		items: r,
-		less: func(i, j interface{}) bool {
+		less: func(i, j any) bool {
 			for _, order := range orders {
 				x, y := order.selector(i), order.selector(j)
 				switch order.compare(x, y) {
@@ -300,9 +270,8 @@ func (q Query) sort(orders []order) (r []interface{}) {
 	return
 }
 
-func (q Query) lessSort(less func(i, j interface{}) bool) (r []interface{}) {
-	next := q.Iterate()
-	for item, ok := next(); ok; item, ok = next() {
+func (q Query) lessSort(less func(i, j any) bool) (r []any) {
+	for item := range q.Iterate {
 		r = append(r, item)
 	}
 

--- a/orderby_test.go
+++ b/orderby_test.go
@@ -1,13 +1,19 @@
 package linq
 
-import "testing"
+import (
+	"iter"
+	"testing"
+)
 
 func TestEmpty(t *testing.T) {
 	q := From([]string{}).OrderBy(func(in interface{}) interface{} {
 		return 0
 	})
 
-	_, ok := q.Iterate()()
+	next, stop := iter.Pull(q.Iterate)
+	defer stop()
+
+	_, ok := next()
 	if ok {
 		t.Errorf("Iterator for empty collection must return ok=false")
 	}
@@ -24,8 +30,10 @@ func TestOrderBy(t *testing.T) {
 		return i.(foo).f1
 	})
 
+	next, stop := iter.Pull(q.Iterate)
+	defer stop()
+
 	j := 0
-	next := q.Iterate()
 	for item, ok := next(); ok; item, ok = next() {
 		if item.(foo).f1 != j {
 			t.Errorf("OrderBy()[%v]=%v expected %v", j, item, foo{f1: j})
@@ -52,8 +60,10 @@ func TestOrderByDescending(t *testing.T) {
 		return i.(foo).f1
 	})
 
+	next, stop := iter.Pull(q.Iterate)
+	defer stop()
+
 	j := len(slice) - 1
-	next := q.Iterate()
 	for item, ok := next(); ok; item, ok = next() {
 		if item.(foo).f1 != j {
 			t.Errorf("OrderByDescending()[%v]=%v expected %v", j, item, foo{f1: j})
@@ -83,7 +93,9 @@ func TestThenBy(t *testing.T) {
 		return i.(foo).f1
 	})
 
-	next := q.Iterate()
+	next, stop := iter.Pull(q.Iterate)
+	defer stop()
+
 	for item, ok := next(); ok; item, ok = next() {
 		if item.(foo).f2 != (item.(foo).f1%2 == 0) {
 			t.Errorf("OrderBy().ThenBy()=%v", item)
@@ -113,7 +125,9 @@ func TestThenByDescending(t *testing.T) {
 		return i.(foo).f1
 	})
 
-	next := q.Iterate()
+	next, stop := iter.Pull(q.Iterate)
+	defer stop()
+
 	for item, ok := next(); ok; item, ok = next() {
 		if item.(foo).f2 != (item.(foo).f1%2 == 0) {
 			t.Errorf("OrderBy().ThenByDescending()=%v", item)
@@ -140,8 +154,10 @@ func TestSort(t *testing.T) {
 		return i.(foo).f1 < j.(foo).f1
 	})
 
+	next, stop := iter.Pull(q.Iterate)
+	defer stop()
+
 	j := 0
-	next := q.Iterate()
 	for item, ok := next(); ok; item, ok = next() {
 		if item.(foo).f1 != j {
 			t.Errorf("Sort()[%v]=%v expected %v", j, item, foo{f1: j})

--- a/orderby_test.go
+++ b/orderby_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestEmpty(t *testing.T) {
-	q := From([]string{}).OrderBy(func(in interface{}) interface{} {
+	q := From([]string{}).OrderBy(func(in any) any {
 		return 0
 	})
 
@@ -26,7 +26,7 @@ func TestOrderBy(t *testing.T) {
 		slice[i].f1 = i
 	}
 
-	q := From(slice).OrderBy(func(i interface{}) interface{} {
+	q := From(slice).OrderBy(func(i any) any {
 		return i.(foo).f1
 	})
 
@@ -56,7 +56,7 @@ func TestOrderByDescending(t *testing.T) {
 		slice[i].f1 = i
 	}
 
-	q := From(slice).OrderByDescending(func(i interface{}) interface{} {
+	q := From(slice).OrderByDescending(func(i any) any {
 		return i.(foo).f1
 	})
 
@@ -87,9 +87,9 @@ func TestThenBy(t *testing.T) {
 		slice[i].f2 = i%2 == 0
 	}
 
-	q := From(slice).OrderBy(func(i interface{}) interface{} {
+	q := From(slice).OrderBy(func(i any) any {
 		return i.(foo).f2
-	}).ThenBy(func(i interface{}) interface{} {
+	}).ThenBy(func(i any) any {
 		return i.(foo).f1
 	})
 
@@ -119,9 +119,9 @@ func TestThenByDescending(t *testing.T) {
 		slice[i].f2 = i%2 == 0
 	}
 
-	q := From(slice).OrderBy(func(i interface{}) interface{} {
+	q := From(slice).OrderBy(func(i any) any {
 		return i.(foo).f2
-	}).ThenByDescending(func(i interface{}) interface{} {
+	}).ThenByDescending(func(i any) any {
 		return i.(foo).f1
 	})
 
@@ -150,7 +150,7 @@ func TestSort(t *testing.T) {
 		slice[i].f1 = i
 	}
 
-	q := From(slice).Sort(func(i, j interface{}) bool {
+	q := From(slice).Sort(func(i, j any) bool {
 		return i.(foo).f1 < j.(foo).f1
 	})
 

--- a/result_test.go
+++ b/result_test.go
@@ -10,10 +10,10 @@ import (
 func TestAll(t *testing.T) {
 	input := []int{2, 4, 6, 8}
 
-	r1 := From(input).All(func(i interface{}) bool {
+	r1 := From(input).All(func(i any) bool {
 		return i.(int)%2 == 0
 	})
-	r2 := From(input).All(func(i interface{}) bool {
+	r2 := From(input).All(func(i any) bool {
 		return i.(int)%2 != 0
 	})
 
@@ -34,7 +34,7 @@ func TestAllT_PanicWhenPredicateFnIsInvalid(t *testing.T) {
 
 func TestAny(t *testing.T) {
 	tests := []struct {
-		input interface{}
+		input any
 		want  bool
 	}{
 		{[]int{1, 2, 2, 3, 1}, true},
@@ -52,7 +52,7 @@ func TestAny(t *testing.T) {
 
 func TestAnyWith(t *testing.T) {
 	tests := []struct {
-		input interface{}
+		input any
 		want  bool
 	}{
 		{[]int{1, 2, 2, 3, 1}, false},
@@ -61,7 +61,7 @@ func TestAnyWith(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if r := From(test.input).AnyWith(func(i interface{}) bool {
+		if r := From(test.input).AnyWith(func(i any) bool {
 			return i.(int) == 4
 		}); r != test.want {
 			t.Errorf("From(%v).Any()=%v expected %v", test.input, r, test.want)
@@ -77,7 +77,7 @@ func TestAnyWithT_PanicWhenPredicateFnIsInvalid(t *testing.T) {
 
 func TestAverage(t *testing.T) {
 	tests := []struct {
-		input interface{}
+		input any
 		want  float64
 	}{
 		{[]int{1, 2, 2, 3, 1}, 1.8},
@@ -100,8 +100,8 @@ func TestAverageForNaN(t *testing.T) {
 
 func TestContains(t *testing.T) {
 	tests := []struct {
-		input interface{}
-		value interface{}
+		input any
+		value any
 		want  bool
 	}{
 		{[]int{1, 2, 2, 3, 1}, 10, false},
@@ -118,7 +118,7 @@ func TestContains(t *testing.T) {
 
 func TestCount(t *testing.T) {
 	tests := []struct {
-		input interface{}
+		input any
 		want  int
 	}{
 		{[]int{1, 2, 2, 3, 1}, 5},
@@ -135,7 +135,7 @@ func TestCount(t *testing.T) {
 
 func TestCountWith(t *testing.T) {
 	tests := []struct {
-		input interface{}
+		input any
 		want  int
 	}{
 		{[]int{1, 2, 2, 3, 1}, 4},
@@ -143,7 +143,7 @@ func TestCountWith(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if r := From(test.input).CountWith(func(i interface{}) bool {
+		if r := From(test.input).CountWith(func(i any) bool {
 			return i.(int) <= 2
 		}); r != test.want {
 			t.Errorf("From(%v).CountWith()=%v expected %v", test.input, r, test.want)
@@ -159,8 +159,8 @@ func TestCountWithT_PanicWhenPredicateFnIsInvalid(t *testing.T) {
 
 func TestFirst(t *testing.T) {
 	tests := []struct {
-		input interface{}
-		want  interface{}
+		input any
+		want  any
 	}{
 		{[]int{1, 2, 2, 3, 1}, 1},
 		{[]int{}, nil},
@@ -175,15 +175,15 @@ func TestFirst(t *testing.T) {
 
 func TestFirstWith(t *testing.T) {
 	tests := []struct {
-		input interface{}
-		want  interface{}
+		input any
+		want  any
 	}{
 		{[]int{1, 2, 2, 3, 1}, 3},
 		{[]int{}, nil},
 	}
 
 	for _, test := range tests {
-		if r := From(test.input).FirstWith(func(i interface{}) bool {
+		if r := From(test.input).FirstWith(func(i any) bool {
 			return i.(int) > 2
 		}); r != test.want {
 			t.Errorf("From(%v).FirstWith()=%v expected %v", test.input, r, test.want)
@@ -199,8 +199,8 @@ func TestFirstWithT_PanicWhenPredicateFnIsInvalid(t *testing.T) {
 
 func TestForEach(t *testing.T) {
 	tests := []struct {
-		input interface{}
-		want  interface{}
+		input any
+		want  any
 	}{
 		{[5]int{1, 2, 2, 35, 111}, []int{2, 4, 4, 70, 222}},
 		{[]int{}, []int{}},
@@ -208,7 +208,7 @@ func TestForEach(t *testing.T) {
 
 	for _, test := range tests {
 		output := []int{}
-		From(test.input).ForEach(func(item interface{}) {
+		From(test.input).ForEach(func(item any) {
 			output = append(output, item.(int)*2)
 		})
 
@@ -226,8 +226,8 @@ func TestForEachT_PanicWhenActionFnIsInvalid(t *testing.T) {
 
 func TestForEachIndexed(t *testing.T) {
 	tests := []struct {
-		input interface{}
-		want  interface{}
+		input any
+		want  any
 	}{
 		{[5]int{1, 2, 2, 35, 111}, []int{1, 3, 4, 38, 115}},
 		{[]int{}, []int{}},
@@ -235,7 +235,7 @@ func TestForEachIndexed(t *testing.T) {
 
 	for _, test := range tests {
 		output := []int{}
-		From(test.input).ForEachIndexed(func(index int, item interface{}) {
+		From(test.input).ForEachIndexed(func(index int, item any) {
 			output = append(output, item.(int)+index)
 		})
 
@@ -253,8 +253,8 @@ func TestForEachIndexedT_PanicWhenActionFnIsInvalid(t *testing.T) {
 
 func TestLast(t *testing.T) {
 	tests := []struct {
-		input interface{}
-		want  interface{}
+		input any
+		want  any
 	}{
 		{[]int{1, 2, 2, 3, 1}, 1},
 		{[]int{}, nil},
@@ -269,15 +269,15 @@ func TestLast(t *testing.T) {
 
 func TestLastWith(t *testing.T) {
 	tests := []struct {
-		input interface{}
-		want  interface{}
+		input any
+		want  any
 	}{
 		{[]int{1, 2, 2, 3, 1, 4, 2, 5, 1, 1}, 5},
 		{[]int{}, nil},
 	}
 
 	for _, test := range tests {
-		if r := From(test.input).LastWith(func(i interface{}) bool {
+		if r := From(test.input).LastWith(func(i any) bool {
 			return i.(int) > 2
 		}); r != test.want {
 			t.Errorf("From(%v).LastWith()=%v expected %v", test.input, r, test.want)
@@ -293,8 +293,8 @@ func TestLastWithT_PanicWhenPredicateFnIsInvalid(t *testing.T) {
 
 func TestMax(t *testing.T) {
 	tests := []struct {
-		input interface{}
-		want  interface{}
+		input any
+		want  any
 	}{
 		{[]int{1, 2, 2, 3, 1}, 3},
 		{[]int{1}, 1},
@@ -310,8 +310,8 @@ func TestMax(t *testing.T) {
 
 func TestMin(t *testing.T) {
 	tests := []struct {
-		input interface{}
-		want  interface{}
+		input any
+		want  any
 	}{
 		{[]int{1, 2, 2, 3, 0}, 0},
 		{[]int{1}, 1},
@@ -327,7 +327,7 @@ func TestMin(t *testing.T) {
 
 func TestResults(t *testing.T) {
 	input := []int{1, 2, 3}
-	want := []interface{}{1, 2, 3}
+	want := []any{1, 2, 3}
 
 	if r := From(input).Results(); !reflect.DeepEqual(r, want) {
 		t.Errorf("From(%v).Raw()=%v expected %v", input, r, want)
@@ -336,8 +336,8 @@ func TestResults(t *testing.T) {
 
 func TestSequenceEqual(t *testing.T) {
 	tests := []struct {
-		input  interface{}
-		input2 interface{}
+		input  any
+		input2 any
 		want   bool
 	}{
 		{[]int{1, 2, 2, 3, 1}, []int{4, 6}, false},
@@ -354,8 +354,8 @@ func TestSequenceEqual(t *testing.T) {
 
 func TestSingle(t *testing.T) {
 	tests := []struct {
-		input interface{}
-		want  interface{}
+		input any
+		want  any
 	}{
 		{[]int{1, 2, 2, 3, 1}, nil},
 		{[]int{1}, 1},
@@ -371,8 +371,8 @@ func TestSingle(t *testing.T) {
 
 func TestSingleWith(t *testing.T) {
 	tests := []struct {
-		input interface{}
-		want  interface{}
+		input any
+		want  any
 	}{
 		{[]int{1, 2, 2, 3, 1}, 3},
 		{[]int{1, 1, 1}, nil},
@@ -381,7 +381,7 @@ func TestSingleWith(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if r := From(test.input).SingleWith(func(i interface{}) bool {
+		if r := From(test.input).SingleWith(func(i any) bool {
 			return i.(int) > 2
 		}); r != test.want {
 			t.Errorf("From(%v).SingleWith()=%v expected %v", test.input, r, test.want)
@@ -397,7 +397,7 @@ func TestSingleWithT_PanicWhenPredicateFnIsInvalid(t *testing.T) {
 
 func TestSumInts(t *testing.T) {
 	tests := []struct {
-		input interface{}
+		input any
 		want  int64
 	}{
 		{[]int{1, 2, 2, 3, 1}, 9},
@@ -414,7 +414,7 @@ func TestSumInts(t *testing.T) {
 
 func TestSumUInts(t *testing.T) {
 	tests := []struct {
-		input interface{}
+		input any
 		want  uint64
 	}{
 		{[]uint{1, 2, 2, 3, 1}, 9},
@@ -431,7 +431,7 @@ func TestSumUInts(t *testing.T) {
 
 func TestSumFloats(t *testing.T) {
 	tests := []struct {
-		input interface{}
+		input any
 		want  float64
 	}{
 		{[]float32{1., 2., 2., 3., 1.}, 9.},
@@ -447,7 +447,7 @@ func TestSumFloats(t *testing.T) {
 }
 
 func TestToChannel(t *testing.T) {
-	c := make(chan interface{})
+	c := make(chan any)
 	input := []int{1, 2, 3, 4, 5}
 
 	go func() {
@@ -502,10 +502,10 @@ func TestToMapBy(t *testing.T) {
 
 	result := make(map[int]bool)
 	From(input).ToMapBy(&result,
-		func(i interface{}) interface{} {
+		func(i any) any {
 			return i.(KeyValue).Key
 		},
-		func(i interface{}) interface{} {
+		func(i any) any {
 			return i.(KeyValue).Value
 		})
 

--- a/reverse.go
+++ b/reverse.go
@@ -7,23 +7,16 @@ package linq
 // the reverse order from which they are produced by the underlying source.
 func (q Query) Reverse() Query {
 	return Query{
-		Iterate: func() Iterator {
-			next := q.Iterate()
-
-			items := []interface{}{}
-			for item, ok := next(); ok; item, ok = next() {
+		Iterate: func(yield func(any) bool) {
+			var items []any
+			for item := range q.Iterate {
 				items = append(items, item)
 			}
 
-			index := len(items) - 1
-			return func() (item interface{}, ok bool) {
-				if index < 0 {
+			for i := len(items) - 1; i >= 0; i-- {
+				if !yield(items[i]) {
 					return
 				}
-
-				item, ok = items[index], true
-				index--
-				return
 			}
 		},
 	}

--- a/reverse_test.go
+++ b/reverse_test.go
@@ -4,10 +4,10 @@ import "testing"
 
 func TestReverse(t *testing.T) {
 	tests := []struct {
-		input interface{}
-		want  []interface{}
+		input any
+		want  []any
 	}{
-		{[]int{1, 2, 3}, []interface{}{3, 2, 1}},
+		{[]int{1, 2, 3}, []any{3, 2, 1}},
 	}
 
 	for _, test := range tests {

--- a/select.go
+++ b/select.go
@@ -2,7 +2,7 @@ package linq
 
 // Select projects each element of a collection into a new form. Returns a query
 // with the result of invoking the transform function on each element of
-// original source.
+// the original source.
 //
 // This projection method requires the transform function, selector, to produce
 // one value for each value in the source collection. If selector returns a
@@ -12,28 +12,21 @@ package linq
 // the SelectMany method instead of Select. Although SelectMany works similarly
 // to Select, it differs in that the transform function returns a collection
 // that is then expanded by SelectMany before it is returned.
-func (q Query) Select(selector func(interface{}) interface{}) Query {
+func (q Query) Select(selector func(any) any) Query {
 	return Query{
-		Iterate: func() Iterator {
-			next := q.Iterate()
-
-			return func() (item interface{}, ok bool) {
-				var it interface{}
-				it, ok = next()
-				if ok {
-					item = selector(it)
-				}
-
-				return
-			}
+		Iterate: func(yield func(any) bool) {
+			q.Iterate(func(item any) bool {
+				return yield(selector(item))
+			})
 		},
 	}
 }
 
 // SelectT is the typed version of Select.
 //   - selectorFn is of type "func(TSource)TResult"
+//
 // NOTE: Select has better performance than SelectT.
-func (q Query) SelectT(selectorFn interface{}) Query {
+func (q Query) SelectT(selectorFn any) Query {
 
 	selectGenericFunc, err := newGenericFunc(
 		"SelectT", "selectorFn", selectorFn,
@@ -43,7 +36,7 @@ func (q Query) SelectT(selectorFn interface{}) Query {
 		panic(err)
 	}
 
-	selectorFunc := func(item interface{}) interface{} {
+	selectorFunc := func(item any) any {
 		return selectGenericFunc.Call(item)
 	}
 
@@ -52,14 +45,14 @@ func (q Query) SelectT(selectorFn interface{}) Query {
 
 // SelectIndexed projects each element of a collection into a new form by
 // incorporating the element's index. Returns a query with the result of
-// invoking the transform function on each element of original source.
+// invoking the transform function on each element of the original source.
 //
 // The first argument to selector represents the zero-based index of that
 // element in the source collection. This can be useful if the elements are in a
-// known order and you want to do something with an element at a particular
+// known order, and you want to do something with an element at a particular
 // index, for example. It can also be useful if you want to retrieve the index
 // of one or more elements. The second argument to selector represents the
-// element to process.
+// element to the process.
 //
 // This projection method requires the transform function, selector, to produce
 // one value for each value in the source collection. If selector returns a
@@ -69,30 +62,24 @@ func (q Query) SelectT(selectorFn interface{}) Query {
 // the SelectMany method instead of Select. Although SelectMany works similarly
 // to Select, it differs in that the transform function returns a collection
 // that is then expanded by SelectMany before it is returned.
-func (q Query) SelectIndexed(selector func(int, interface{}) interface{}) Query {
+func (q Query) SelectIndexed(selector func(int, any) any) Query {
 	return Query{
-		Iterate: func() Iterator {
-			next := q.Iterate()
+		Iterate: func(yield func(any) bool) {
 			index := 0
-
-			return func() (item interface{}, ok bool) {
-				var it interface{}
-				it, ok = next()
-				if ok {
-					item = selector(index, it)
-					index++
-				}
-
-				return
-			}
+			q.Iterate(func(item any) bool {
+				newItem := selector(index, item)
+				index++
+				return yield(newItem)
+			})
 		},
 	}
 }
 
 // SelectIndexedT is the typed version of SelectIndexed.
 //   - selectorFn is of type "func(int,TSource)TResult"
+//
 // NOTE: SelectIndexed has better performance than SelectIndexedT.
-func (q Query) SelectIndexedT(selectorFn interface{}) Query {
+func (q Query) SelectIndexedT(selectorFn any) Query {
 	selectGenericFunc, err := newGenericFunc(
 		"SelectIndexedT", "selectorFn", selectorFn,
 		simpleParamValidator(newElemTypeSlice(new(int), new(genericType)), newElemTypeSlice(new(genericType))),
@@ -101,7 +88,7 @@ func (q Query) SelectIndexedT(selectorFn interface{}) Query {
 		panic(err)
 	}
 
-	selectorFunc := func(index int, item interface{}) interface{} {
+	selectorFunc := func(index int, item any) any {
 		return selectGenericFunc.Call(index, item)
 	}
 

--- a/select_test.go
+++ b/select_test.go
@@ -7,16 +7,16 @@ import (
 
 func TestSelect(t *testing.T) {
 	tests := []struct {
-		input    interface{}
-		selector func(interface{}) interface{}
-		output   []interface{}
+		input    any
+		selector func(any) any
+		output   []any
 	}{
-		{[]int{1, 2, 3}, func(i interface{}) interface{} {
+		{[]int{1, 2, 3}, func(i any) any {
 			return i.(int) * 2
-		}, []interface{}{2, 4, 6}},
-		{"str", func(i interface{}) interface{} {
+		}, []any{2, 4, 6}},
+		{"str", func(i any) any {
 			return string(i.(rune)) + "1"
-		}, []interface{}{"s1", "t1", "r1"}},
+		}, []any{"s1", "t1", "r1"}},
 	}
 
 	for _, test := range tests {
@@ -34,16 +34,16 @@ func TestSelectT_PanicWhenSelectorFnIsInvalid(t *testing.T) {
 
 func TestSelectIndexed(t *testing.T) {
 	tests := []struct {
-		input    interface{}
-		selector func(int, interface{}) interface{}
-		output   []interface{}
+		input    any
+		selector func(int, any) any
+		output   []any
 	}{
-		{[]int{1, 2, 3}, func(i int, x interface{}) interface{} {
+		{[]int{1, 2, 3}, func(i int, x any) any {
 			return x.(int) * i
-		}, []interface{}{0, 2, 6}},
-		{"str", func(i int, x interface{}) interface{} {
+		}, []any{0, 2, 6}},
+		{"str", func(i int, x any) any {
 			return string(x.(rune)) + strconv.Itoa(i)
-		}, []interface{}{"s0", "t1", "r2"}},
+		}, []any{"s0", "t1", "r2"}},
 	}
 
 	for _, test := range tests {

--- a/selectmany_test.go
+++ b/selectmany_test.go
@@ -7,16 +7,16 @@ import (
 
 func TestSelectMany(t *testing.T) {
 	tests := []struct {
-		input    interface{}
-		selector func(interface{}) Query
-		output   []interface{}
+		input    any
+		selector func(any) Query
+		output   []any
 	}{
-		{[][]int{{1, 2, 3}, {4, 5, 6, 7}}, func(i interface{}) Query {
+		{[][]int{{1, 2, 3}, {4, 5, 6, 7}}, func(i any) Query {
 			return From(i)
-		}, []interface{}{1, 2, 3, 4, 5, 6, 7}},
-		{[]string{"str", "ing"}, func(i interface{}) Query {
+		}, []any{1, 2, 3, 4, 5, 6, 7}},
+		{[]string{"str", "ing"}, func(i any) Query {
 			return FromString(i.(string))
-		}, []interface{}{'s', 't', 'r', 'i', 'n', 'g'}},
+		}, []any{'s', 't', 'r', 'i', 'n', 'g'}},
 	}
 
 	for _, test := range tests {
@@ -34,19 +34,19 @@ func TestSelectManyT_PanicWhenSelectorFnIsInvalid(t *testing.T) {
 
 func TestSelectManyIndexed(t *testing.T) {
 	tests := []struct {
-		input    interface{}
-		selector func(int, interface{}) Query
-		output   []interface{}
+		input    any
+		selector func(int, any) Query
+		output   []any
 	}{
-		{[][]int{{1, 2, 3}, {4, 5, 6, 7}}, func(i int, x interface{}) Query {
+		{[][]int{{1, 2, 3}, {4, 5, 6, 7}}, func(i int, x any) Query {
 			if i > 0 {
 				return From(x.([]int)[1:])
 			}
 			return From(x)
-		}, []interface{}{1, 2, 3, 5, 6, 7}},
-		{[]string{"str", "ing"}, func(i int, x interface{}) Query {
+		}, []any{1, 2, 3, 5, 6, 7}},
+		{[]string{"str", "ing"}, func(i int, x any) Query {
 			return FromString(x.(string) + strconv.Itoa(i))
-		}, []interface{}{'s', 't', 'r', '0', 'i', 'n', 'g', '1'}},
+		}, []any{'s', 't', 'r', '0', 'i', 'n', 'g', '1'}},
 	}
 
 	for _, test := range tests {
@@ -64,21 +64,21 @@ func TestSelectManyIndexedT_PanicWhenSelectorFnIsInvalid(t *testing.T) {
 
 func TestSelectManyBy(t *testing.T) {
 	tests := []struct {
-		input          interface{}
-		selector       func(interface{}) Query
-		resultSelector func(interface{}, interface{}) interface{}
-		output         []interface{}
+		input          any
+		selector       func(any) Query
+		resultSelector func(any, any) any
+		output         []any
 	}{
-		{[][]int{{1, 2, 3}, {4, 5, 6, 7}}, func(i interface{}) Query {
+		{[][]int{{1, 2, 3}, {4, 5, 6, 7}}, func(i any) Query {
 			return From(i)
-		}, func(x interface{}, y interface{}) interface{} {
+		}, func(x any, y any) any {
 			return x.(int) + 1
-		}, []interface{}{2, 3, 4, 5, 6, 7, 8}},
-		{[]string{"str", "ing"}, func(i interface{}) Query {
+		}, []any{2, 3, 4, 5, 6, 7, 8}},
+		{[]string{"str", "ing"}, func(i any) Query {
 			return FromString(i.(string))
-		}, func(x interface{}, y interface{}) interface{} {
+		}, func(x any, y any) any {
 			return string(x.(rune)) + "_"
-		}, []interface{}{"s_", "t_", "r_", "i_", "n_", "g_"}},
+		}, []any{"s_", "t_", "r_", "i_", "n_", "g_"}},
 	}
 
 	for _, test := range tests {
@@ -90,14 +90,14 @@ func TestSelectManyBy(t *testing.T) {
 
 func TestSelectManyByT_PanicWhenSelectorFnIsInvalid(t *testing.T) {
 	mustPanicWithError(t, "SelectManyByT: parameter [selectorFn] has a invalid function signature. Expected: 'func(T)linq.Query', actual: 'func(int)interface {}'", func() {
-		From([]int{1, 1, 1, 2, 1, 2, 3, 4, 2}).SelectManyByT(func(item int) interface{} { return item + 2 }, 2)
+		From([]int{1, 1, 1, 2, 1, 2, 3, 4, 2}).SelectManyByT(func(item int) any { return item + 2 }, 2)
 	})
 }
 
 func TestSelectManyByT_PanicWhenResultSelectorFnIsInvalid(t *testing.T) {
 	mustPanicWithError(t, "SelectManyByT: parameter [resultSelectorFn] has a invalid function signature. Expected: 'func(T,T)T', actual: 'func()'", func() {
 		From([][]int{{1, 1, 1, 2}, {1, 2, 3, 4, 2}}).SelectManyByT(
-			func(item interface{}) Query { return From(item) },
+			func(item any) Query { return From(item) },
 			func() {},
 		)
 	})
@@ -105,27 +105,27 @@ func TestSelectManyByT_PanicWhenResultSelectorFnIsInvalid(t *testing.T) {
 
 func TestSelectManyIndexedBy(t *testing.T) {
 	tests := []struct {
-		input          interface{}
-		selector       func(int, interface{}) Query
-		resultSelector func(interface{}, interface{}) interface{}
-		output         []interface{}
+		input          any
+		selector       func(int, any) Query
+		resultSelector func(any, any) any
+		output         []any
 	}{
-		{[][]int{{1, 2, 3}, {4, 5, 6, 7}}, func(i int, x interface{}) Query {
+		{[][]int{{1, 2, 3}, {4, 5, 6, 7}}, func(i int, x any) Query {
 			if i == 0 {
 				return From([]int{10, 20, 30})
 			}
 			return From(x)
-		}, func(x interface{}, y interface{}) interface{} {
+		}, func(x any, y any) any {
 			return x.(int) + 1
-		}, []interface{}{11, 21, 31, 5, 6, 7, 8}},
-		{[]string{"st", "ng"}, func(i int, x interface{}) Query {
+		}, []any{11, 21, 31, 5, 6, 7, 8}},
+		{[]string{"st", "ng"}, func(i int, x any) Query {
 			if i == 0 {
 				return FromString(x.(string) + "r")
 			}
 			return FromString("i" + x.(string))
-		}, func(x interface{}, y interface{}) interface{} {
+		}, func(x any, y any) any {
 			return string(x.(rune)) + "_"
-		}, []interface{}{"s_", "t_", "r_", "i_", "n_", "g_"}},
+		}, []any{"s_", "t_", "r_", "i_", "n_", "g_"}},
 	}
 
 	for _, test := range tests {
@@ -138,7 +138,7 @@ func TestSelectManyIndexedBy(t *testing.T) {
 func TestSelectManyIndexedByT_PanicWhenSelectorFnIsInvalid(t *testing.T) {
 	mustPanicWithError(t, "SelectManyByIndexedT: parameter [selectorFn] has a invalid function signature. Expected: 'func(int,T)linq.Query', actual: 'func(int)interface {}'", func() {
 		From([][]int{{1, 1, 1, 2}, {1, 2, 3, 4, 2}}).SelectManyByIndexedT(
-			func(item int) interface{} { return item + 2 },
+			func(item int) any { return item + 2 },
 			2,
 		)
 	})
@@ -147,7 +147,7 @@ func TestSelectManyIndexedByT_PanicWhenSelectorFnIsInvalid(t *testing.T) {
 func TestSelectManyIndexedByT_PanicWhenResultSelectorFnIsInvalid(t *testing.T) {
 	mustPanicWithError(t, "SelectManyByIndexedT: parameter [resultSelectorFn] has a invalid function signature. Expected: 'func(T,T)T', actual: 'func()'", func() {
 		From([][]int{{1, 1, 1, 2}, {1, 2, 3, 4, 2}}).SelectManyByIndexedT(
-			func(index int, item interface{}) Query { return From(item) },
+			func(index int, item any) Query { return From(item) },
 			func() {},
 		)
 	})

--- a/setup_test.go
+++ b/setup_test.go
@@ -1,8 +1,11 @@
 package linq
 
-import "testing"
-
-import "fmt"
+import (
+	"fmt"
+	"iter"
+	"slices"
+	"testing"
+)
 
 type foo struct {
 	f1 int
@@ -10,26 +13,20 @@ type foo struct {
 	f3 string
 }
 
-func (f foo) Iterate() Iterator {
-	i := 0
-
-	return func() (item interface{}, ok bool) {
-		switch i {
-		case 0:
-			item = f.f1
-			ok = true
-		case 1:
-			item = f.f2
-			ok = true
-		case 2:
-			item = f.f3
-			ok = true
-		default:
-			ok = false
+func (f foo) Iterate() iter.Seq[any] {
+	return func(yield func(any) bool) {
+		// Yield the first field and check if we should continue.
+		if !yield(f.f1) {
+			return
 		}
 
-		i++
-		return
+		// Yield the second field and check if we should continue.
+		if !yield(f.f2) {
+			return
+		}
+
+		// Yield the third and final field.
+		yield(f.f3)
 	}
 }
 
@@ -45,30 +42,17 @@ func (f foo) CompareTo(c Comparable) int {
 	return 0
 }
 
-func toSlice(q Query) (result []interface{}) {
-	next := q.Iterate()
-
-	for item, ok := next(); ok; item, ok = next() {
+func toSlice(q Query) (result []any) {
+	q.Iterate(func(item any) bool {
 		result = append(result, item)
-	}
+		return true
+	})
 
 	return
 }
 
-func validateQuery(q Query, output []interface{}) bool {
-	next := q.Iterate()
-
-	for _, oitem := range output {
-		qitem, _ := next()
-
-		if oitem != qitem {
-			return false
-		}
-	}
-
-	_, ok := next()
-	_, ok2 := next()
-	return !(ok || ok2)
+func validateQuery(q Query, expected []any) bool {
+	return slices.Equal(toSlice(q), expected)
 }
 
 func mustPanicWithError(t *testing.T, expectedErr string, f func()) {

--- a/skip_test.go
+++ b/skip_test.go
@@ -4,13 +4,13 @@ import "testing"
 
 func TestSkip(t *testing.T) {
 	tests := []struct {
-		input  interface{}
-		output []interface{}
+		input  any
+		output []any
 	}{
-		{[]int{1, 2}, []interface{}{}},
-		{[]int{1, 2, 2, 3, 1}, []interface{}{3, 1}},
-		{[9]int{1, 1, 1, 2, 1, 2, 3, 4, 2}, []interface{}{2, 1, 2, 3, 4, 2}},
-		{"sstr", []interface{}{'r'}},
+		{[]int{1, 2}, []any{}},
+		{[]int{1, 2, 2, 3, 1}, []any{3, 1}},
+		{[9]int{1, 1, 1, 2, 1, 2, 3, 4, 2}, []any{2, 1, 2, 3, 4, 2}},
+		{"sstr", []any{'r'}},
 	}
 
 	for _, test := range tests {
@@ -22,22 +22,22 @@ func TestSkip(t *testing.T) {
 
 func TestSkipWhile(t *testing.T) {
 	tests := []struct {
-		input     interface{}
-		predicate func(interface{}) bool
-		output    []interface{}
+		input     any
+		predicate func(any) bool
+		output    []any
 	}{
-		{[]int{1, 2}, func(i interface{}) bool {
+		{[]int{1, 2}, func(i any) bool {
 			return i.(int) < 3
-		}, []interface{}{}},
-		{[]int{4, 1, 2}, func(i interface{}) bool {
+		}, []any{}},
+		{[]int{4, 1, 2}, func(i any) bool {
 			return i.(int) < 3
-		}, []interface{}{4, 1, 2}},
-		{[9]int{1, 1, 1, 2, 1, 2, 3, 4, 2}, func(i interface{}) bool {
+		}, []any{4, 1, 2}},
+		{[9]int{1, 1, 1, 2, 1, 2, 3, 4, 2}, func(i any) bool {
 			return i.(int) < 3
-		}, []interface{}{3, 4, 2}},
-		{"sstr", func(i interface{}) bool {
+		}, []any{3, 4, 2}},
+		{"sstr", func(i any) bool {
 			return i.(rune) == 's'
-		}, []interface{}{'t', 'r'}},
+		}, []any{'t', 'r'}},
 	}
 
 	for _, test := range tests {
@@ -55,22 +55,22 @@ func TestSkipWhileT_PanicWhenPredicateFnIsInvalid(t *testing.T) {
 
 func TestSkipWhileIndexed(t *testing.T) {
 	tests := []struct {
-		input     interface{}
-		predicate func(int, interface{}) bool
-		output    []interface{}
+		input     any
+		predicate func(int, any) bool
+		output    []any
 	}{
-		{[]int{1, 2}, func(i int, x interface{}) bool {
+		{[]int{1, 2}, func(i int, x any) bool {
 			return x.(int) < 3
-		}, []interface{}{}},
-		{[]int{4, 1, 2}, func(i int, x interface{}) bool {
+		}, []any{}},
+		{[]int{4, 1, 2}, func(i int, x any) bool {
 			return x.(int) < 3
-		}, []interface{}{4, 1, 2}},
-		{[9]int{1, 1, 1, 2, 1, 2, 3, 4, 2}, func(i int, x interface{}) bool {
+		}, []any{4, 1, 2}},
+		{[9]int{1, 1, 1, 2, 1, 2, 3, 4, 2}, func(i int, x any) bool {
 			return x.(int) < 2 || i < 5
-		}, []interface{}{2, 3, 4, 2}},
-		{"sstr", func(i int, x interface{}) bool {
+		}, []any{2, 3, 4, 2}},
+		{"sstr", func(i int, x any) bool {
 			return x.(rune) == 's' && i < 1
-		}, []interface{}{'s', 't', 'r'}},
+		}, []any{'s', 't', 'r'}},
 	}
 
 	for _, test := range tests {

--- a/take_test.go
+++ b/take_test.go
@@ -4,12 +4,12 @@ import "testing"
 
 func TestTake(t *testing.T) {
 	tests := []struct {
-		input  interface{}
-		output []interface{}
+		input  any
+		output []any
 	}{
-		{[]int{1, 2, 2, 3, 1}, []interface{}{1, 2, 2}},
-		{[9]int{1, 1, 1, 2, 1, 2, 3, 4, 2}, []interface{}{1, 1, 1}},
-		{"sstr", []interface{}{'s', 's', 't'}},
+		{[]int{1, 2, 2, 3, 1}, []any{1, 2, 2}},
+		{[9]int{1, 1, 1, 2, 1, 2, 3, 4, 2}, []any{1, 1, 1}},
+		{"sstr", []any{'s', 's', 't'}},
 	}
 
 	for _, test := range tests {
@@ -21,19 +21,19 @@ func TestTake(t *testing.T) {
 
 func TestTakeWhile(t *testing.T) {
 	tests := []struct {
-		input     interface{}
-		predicate func(interface{}) bool
-		output    []interface{}
+		input     any
+		predicate func(any) bool
+		output    []any
 	}{
-		{[]int{1, 1, 1, 2, 1, 2}, func(i interface{}) bool {
+		{[]int{1, 1, 1, 2, 1, 2}, func(i any) bool {
 			return i.(int) < 3
-		}, []interface{}{1, 1, 1, 2, 1, 2}},
-		{[9]int{1, 1, 1, 2, 1, 2, 3, 4, 2}, func(i interface{}) bool {
+		}, []any{1, 1, 1, 2, 1, 2}},
+		{[9]int{1, 1, 1, 2, 1, 2, 3, 4, 2}, func(i any) bool {
 			return i.(int) < 3
-		}, []interface{}{1, 1, 1, 2, 1, 2}},
-		{"sstr", func(i interface{}) bool {
+		}, []any{1, 1, 1, 2, 1, 2}},
+		{"sstr", func(i any) bool {
 			return i.(rune) == 's'
-		}, []interface{}{'s', 's'}},
+		}, []any{'s', 's'}},
 	}
 
 	for _, test := range tests {
@@ -51,19 +51,19 @@ func TestTakeWhileT_PanicWhenPredicateFnIsInvalid(t *testing.T) {
 
 func TestTakeWhileIndexed(t *testing.T) {
 	tests := []struct {
-		input     interface{}
-		predicate func(int, interface{}) bool
-		output    []interface{}
+		input     any
+		predicate func(int, any) bool
+		output    []any
 	}{
-		{[]int{1, 1, 1, 2}, func(i int, x interface{}) bool {
+		{[]int{1, 1, 1, 2}, func(i int, x any) bool {
 			return x.(int) < 2 || i < 5
-		}, []interface{}{1, 1, 1, 2}},
-		{[9]int{1, 1, 1, 2, 1, 2, 3, 4, 2}, func(i int, x interface{}) bool {
+		}, []any{1, 1, 1, 2}},
+		{[9]int{1, 1, 1, 2, 1, 2, 3, 4, 2}, func(i int, x any) bool {
 			return x.(int) < 2 || i < 5
-		}, []interface{}{1, 1, 1, 2, 1}},
-		{"sstr", func(i int, x interface{}) bool {
+		}, []any{1, 1, 1, 2, 1}},
+		{"sstr", func(i int, x any) bool {
 			return x.(rune) == 's' && i < 1
-		}, []interface{}{'s'}},
+		}, []any{'s'}},
 	}
 
 	for _, test := range tests {

--- a/union_test.go
+++ b/union_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestUnion(t *testing.T) {
 	input1 := []int{1, 2, 3}
 	input2 := []int{2, 4, 5, 1}
-	want := []interface{}{1, 2, 3, 4, 5}
+	want := []any{1, 2, 3, 4, 5}
 
 	if q := From(input1).Union(From(input2)); !validateQuery(q, want) {
 		t.Errorf("From(%v).Union(%v)=%v expected %v", input1, input2, toSlice(q), want)

--- a/where.go
+++ b/where.go
@@ -1,20 +1,15 @@
 package linq
 
 // Where filters a collection of values based on a predicate.
-func (q Query) Where(predicate func(interface{}) bool) Query {
+func (q Query) Where(predicate func(any) bool) Query {
 	return Query{
-		Iterate: func() Iterator {
-			next := q.Iterate()
-
-			return func() (item interface{}, ok bool) {
-				for item, ok = next(); ok; item, ok = next() {
-					if predicate(item) {
-						return
-					}
+		Iterate: func(yield func(any) bool) {
+			q.Iterate(func(item any) bool {
+				if predicate(item) {
+					return yield(item)
 				}
-
-				return
-			}
+				return true
+			})
 		},
 	}
 }
@@ -24,7 +19,7 @@ func (q Query) Where(predicate func(interface{}) bool) Query {
 //   - predicateFn is of type "func(TSource)bool"
 //
 // NOTE: Where has better performance than WhereT.
-func (q Query) WhereT(predicateFn interface{}) Query {
+func (q Query) WhereT(predicateFn any) Query {
 
 	predicateGenericFunc, err := newGenericFunc(
 		"WhereT", "predicateFn", predicateFn,
@@ -34,7 +29,7 @@ func (q Query) WhereT(predicateFn interface{}) Query {
 		panic(err)
 	}
 
-	predicateFunc := func(item interface{}) bool {
+	predicateFunc := func(item any) bool {
 		return predicateGenericFunc.Call(item).(bool)
 	}
 
@@ -45,25 +40,21 @@ func (q Query) WhereT(predicateFn interface{}) Query {
 // element's index is used in the logic of the predicate function.
 //
 // The first argument represents the zero-based index of the element within
-// collection. The second argument of predicate represents the element to test.
-func (q Query) WhereIndexed(predicate func(int, interface{}) bool) Query {
+// the collection. The second argument of predicate represents the element to test.
+func (q Query) WhereIndexed(predicate func(int, any) bool) Query {
 	return Query{
-		Iterate: func() Iterator {
-			next := q.Iterate()
+		Iterate: func(yield func(any) bool) {
 			index := 0
+			q.Iterate(func(item any) bool {
+				shouldYield := predicate(index, item)
+				index++
 
-			return func() (item interface{}, ok bool) {
-				for item, ok = next(); ok; item, ok = next() {
-					if predicate(index, item) {
-						index++
-						return
-					}
-
-					index++
+				if shouldYield {
+					return yield(item)
 				}
 
-				return
-			}
+				return true
+			})
 		},
 	}
 }
@@ -73,7 +64,7 @@ func (q Query) WhereIndexed(predicate func(int, interface{}) bool) Query {
 //   - predicateFn is of type "func(int,TSource)bool"
 //
 // NOTE: WhereIndexed has better performance than WhereIndexedT.
-func (q Query) WhereIndexedT(predicateFn interface{}) Query {
+func (q Query) WhereIndexedT(predicateFn any) Query {
 	predicateGenericFunc, err := newGenericFunc(
 		"WhereIndexedT", "predicateFn", predicateFn,
 		simpleParamValidator(newElemTypeSlice(new(int), new(genericType)), newElemTypeSlice(new(bool))),
@@ -82,7 +73,7 @@ func (q Query) WhereIndexedT(predicateFn interface{}) Query {
 		panic(err)
 	}
 
-	predicateFunc := func(index int, item interface{}) bool {
+	predicateFunc := func(index int, item any) bool {
 		return predicateGenericFunc.Call(index, item).(bool)
 	}
 

--- a/where_test.go
+++ b/where_test.go
@@ -4,16 +4,16 @@ import "testing"
 
 func TestWhere(t *testing.T) {
 	tests := []struct {
-		input     interface{}
-		predicate func(interface{}) bool
-		output    []interface{}
+		input     any
+		predicate func(any) bool
+		output    []any
 	}{
-		{[9]int{1, 1, 1, 2, 1, 2, 3, 4, 2}, func(i interface{}) bool {
+		{[9]int{1, 1, 1, 2, 1, 2, 3, 4, 2}, func(i any) bool {
 			return i.(int) >= 3
-		}, []interface{}{3, 4}},
-		{"sstr", func(i interface{}) bool {
+		}, []any{3, 4}},
+		{"sstr", func(i any) bool {
 			return i.(rune) != 's'
-		}, []interface{}{'t', 'r'}},
+		}, []any{'t', 'r'}},
 	}
 
 	for _, test := range tests {
@@ -31,19 +31,19 @@ func TestWhereT_PanicWhenPredicateFnIsInvalid(t *testing.T) {
 
 func TestWhereIndexed(t *testing.T) {
 	tests := []struct {
-		input     interface{}
-		predicate func(int, interface{}) bool
-		output    []interface{}
+		input     any
+		predicate func(int, any) bool
+		output    []any
 	}{
-		{[9]int{1, 1, 1, 2, 1, 2, 3, 4, 2}, func(i int, x interface{}) bool {
+		{[9]int{1, 1, 1, 2, 1, 2, 3, 4, 2}, func(i int, x any) bool {
 			return x.(int) < 4 && i > 4
-		}, []interface{}{2, 3, 2}},
-		{"sstr", func(i int, x interface{}) bool {
+		}, []any{2, 3, 2}},
+		{"sstr", func(i int, x any) bool {
 			return x.(rune) != 's' || i == 1
-		}, []interface{}{'s', 't', 'r'}},
-		{"abcde", func(i int, _ interface{}) bool {
+		}, []any{'s', 't', 'r'}},
+		{"abcde", func(i int, _ any) bool {
 			return i < 2
-		}, []interface{}{'a', 'b'}},
+		}, []any{'a', 'b'}},
 	}
 
 	for _, test := range tests {

--- a/zip.go
+++ b/zip.go
@@ -1,5 +1,7 @@
 package linq
 
+import "iter"
+
 // Zip applies a specified function to the corresponding elements of two
 // collections, producing a collection of the results.
 //
@@ -11,22 +13,28 @@ package linq
 // example, if one collection has three elements and the other one has four, the
 // result collection has only three elements.
 func (q Query) Zip(q2 Query,
-	resultSelector func(interface{}, interface{}) interface{}) Query {
+	resultSelector func(any, any) any) Query {
 
 	return Query{
-		Iterate: func() Iterator {
-			next1 := q.Iterate()
-			next2 := q2.Iterate()
+		Iterate: func(yield func(any) bool) {
+			next1, stop1 := iter.Pull(q.Iterate)
+			defer stop1()
 
-			return func() (item interface{}, ok bool) {
+			next2, stop2 := iter.Pull(q2.Iterate)
+			defer stop2()
+
+			for {
 				item1, ok1 := next1()
 				item2, ok2 := next2()
 
-				if ok1 && ok2 {
-					return resultSelector(item1, item2), true
+				if !(ok1 && ok2) {
+					return
 				}
 
-				return nil, false
+				result := resultSelector(item1, item2)
+				if !yield(result) {
+					return
+				}
 			}
 		},
 	}
@@ -38,7 +46,7 @@ func (q Query) Zip(q2 Query,
 //
 // NOTE: Zip has better performance than ZipT.
 func (q Query) ZipT(q2 Query,
-	resultSelectorFn interface{}) Query {
+	resultSelectorFn any) Query {
 	resultSelectorGenericFunc, err := newGenericFunc(
 		"ZipT", "resultSelectorFn", resultSelectorFn,
 		simpleParamValidator(newElemTypeSlice(new(genericType), new(genericType)), newElemTypeSlice(new(genericType))),
@@ -47,7 +55,7 @@ func (q Query) ZipT(q2 Query,
 		panic(err)
 	}
 
-	resultSelectorFunc := func(item1 interface{}, item2 interface{}) interface{} {
+	resultSelectorFunc := func(item1 any, item2 any) any {
 		return resultSelectorGenericFunc.Call(item1, item2)
 	}
 

--- a/zip_test.go
+++ b/zip_test.go
@@ -5,9 +5,9 @@ import "testing"
 func TestZip(t *testing.T) {
 	input1 := []int{1, 2, 3}
 	input2 := []int{2, 4, 5, 1}
-	want := []interface{}{3, 6, 8}
+	want := []any{3, 6, 8}
 
-	if q := From(input1).Zip(From(input2), func(i, j interface{}) interface{} {
+	if q := From(input1).Zip(From(input2), func(i, j any) any {
 		return i.(int) + j.(int)
 	}); !validateQuery(q, want) {
 		t.Errorf("From(%v).Zip(%v)=%v expected %v", input1, input2, toSlice(q), want)


### PR DESCRIPTION
This PR introduces a significant update to go-linq with a focus on modern Go patterns and improved developer experience.

## Key Changes

1. Adoption of Standard Iterator Pattern (Go 1.23+)
Migrated to the standard iterator pattern introduced in Go 1.23, aligning the library with the current language best practices.

⚠️ Breaking Change: Manual iteration over Query is part of the public API, and its behavior has changed to comply with the new standard iterator design. Users who rely on manual iteration will need to update their code accordingly.

2. Generic From* Methods
While Go generics still don’t allow adding new type parameters (making certain methods like Select hard to express with generics), we can leverage them for the From* family of methods.
  - Added strongly-typed constructors for slice, map, channel, and string.
  - The generic `From()` method is preserved for convenience and backward compatibility, but its usage is discouraged in favor of the typed methods.

3. Use of `any` instead of `interface{}`
Updated the codebase to use any in place of interface{}, improving readability and aligning with modern Go conventions.

## Notes

- The switch to the standard iterator pattern introduces a breaking change in the public API. Please review your code if you rely on manual iteration over `Query`.

- Existing code using `From()` will continue to work, but developers are encouraged to migrate to the new `From*` methods.

- These changes make the API more idiomatic, type-safe, and easier to understand.