### PR TITLE
perf: propagate derived size hints

### DIFF
--- a/concat.go
+++ b/concat.go
@@ -1,5 +1,22 @@
 package linq
 
+import "math"
+
+// concatSize returns the exact size of a query that yields every element of a
+// size-a sequence followed by every element of a size-b one. Both arguments are
+// sizes, never deltas, so zero means unknown and the result is known only when
+// both inputs are and their sum fits in an int.
+//
+// Only the concatenating operators need this. An operator that shifts a size by
+// a constant (Skip, Take) clamps with min or max instead, which already treat
+// the zero sentinel correctly; plain addition does not.
+func concatSize(a, b int) int {
+	if a <= 0 || b <= 0 || a > math.MaxInt-b {
+		return 0
+	}
+	return a + b
+}
+
 // Append inserts an item to the end of a collection, so it becomes the last
 // item.
 func (q Query[T]) Append(item T) Query[T] {
@@ -19,6 +36,7 @@ func (q Query[T]) Append(item T) Query[T] {
 				yield(item)
 			}
 		},
+		size: concatSize(q.size, 1),
 	}
 }
 
@@ -44,6 +62,7 @@ func (q Query[T]) Concat(q2 Query[T]) Query[T] {
 				q2.Iterate(yield)
 			}
 		},
+		size: concatSize(q.size, q2.size),
 	}
 }
 
@@ -58,5 +77,6 @@ func (q Query[T]) Prepend(item T) Query[T] {
 
 			q.Iterate(yield)
 		},
+		size: concatSize(q.size, 1),
 	}
 }

--- a/concat.go
+++ b/concat.go
@@ -2,14 +2,7 @@ package linq
 
 import "math"
 
-// concatSize returns the exact size of a query that yields every element of a
-// size-a sequence followed by every element of a size-b one. Both arguments are
-// sizes, never deltas, so zero means unknown and the result is known only when
-// both inputs are and their sum fits in an int.
-//
-// Only the concatenating operators need this. An operator that shifts a size by
-// a constant (Skip, Take) clamps with min or max instead, which already treat
-// the zero sentinel correctly; plain addition does not.
+// concatSize adds known size hints, returning zero for an unknown input or overflow.
 func concatSize(a, b int) int {
 	if a <= 0 || b <= 0 || a > math.MaxInt-b {
 		return 0

--- a/defaultifempty.go
+++ b/defaultifempty.go
@@ -24,5 +24,8 @@ func (q Query[T]) DefaultIfEmpty(defaultValue T) Query[T] {
 				yield(defaultValue)
 			}
 		},
+		// A non-zero hint means the source is non-empty, so the default value
+		// is never yielded and the element count is unchanged.
+		size: q.size,
 	}
 }

--- a/defaultifempty.go
+++ b/defaultifempty.go
@@ -24,8 +24,6 @@ func (q Query[T]) DefaultIfEmpty(defaultValue T) Query[T] {
 				yield(defaultValue)
 			}
 		},
-		// A non-zero hint means the source is non-empty, so the default value
-		// is never yielded and the element count is unchanged.
 		size: q.size,
 	}
 }

--- a/from.go
+++ b/from.go
@@ -54,14 +54,8 @@ type KeyValue[TKey comparable, TValue any] struct {
 // FromSlice initializes a linq query with a passed slice.
 func FromSlice[S ~[]T, T any](source S) Query[T] {
 	return Query[T]{
-		Iterate: func(yield func(T) bool) {
-			for _, item := range source {
-				if !yield(item) {
-					return
-				}
-			}
-		},
-		size: len(source),
+		Iterate: slices.Values(source),
+		size:    len(source),
 	}
 }
 

--- a/from.go
+++ b/from.go
@@ -14,10 +14,9 @@ type Query[T any] struct {
 
 	// size hints the exact number of elements the query yields, when that is
 	// cheaply known; zero means unknown. Sources with a known length set it,
-	// and only operators that emit exactly one element per source element may
-	// propagate it. Operators that change cardinality need to do nothing:
-	// they construct a fresh Query without the field, and the hint safely
-	// zeroes out.
+	// and operators may propagate a size that can be derived exactly from their
+	// inputs. Operators whose cardinality is unknown construct a fresh Query
+	// without the field, and the hint safely zeroes out.
 	//
 	// The hint is consumed only as the capacity of preallocated result
 	// slices, so it can never change what a query produces. A missing hint

--- a/from.go
+++ b/from.go
@@ -12,16 +12,11 @@ import (
 type Query[T any] struct {
 	Iterate iter.Seq[T]
 
-	// size hints the exact number of elements the query yields, when that is
-	// cheaply known; zero means unknown. Sources with a known length set it,
-	// and operators may propagate a size that can be derived exactly from their
-	// inputs. Operators whose cardinality is unknown construct a fresh Query
-	// without the field, and the hint safely zeroes out.
+	// size is the exact number of yielded elements when cheaply known; zero means
+	// unknown. Operators may propagate it only when they can derive an exact count.
 	//
-	// The hint is consumed only as the capacity of preallocated result
-	// slices, so it can never change what a query produces. A missing hint
-	// forfeits the preallocation; a stale one (e.g., a source map mutated
-	// after the query was built) merely mis-sizes it.
+	// It is used only for preallocation, so missing or stale hints affect
+	// allocations, not the elements yielded.
 	size int
 }
 

--- a/groupjoin.go
+++ b/groupjoin.go
@@ -44,5 +44,6 @@ func (q Query[T]) GroupJoin[TInner any, TKey comparable, TResult any](inner Quer
 				return yield(resultSelector(outerItem, innerGroup))
 			})
 		},
+		size: q.size,
 	}
 }

--- a/groupjoin_test.go
+++ b/groupjoin_test.go
@@ -18,6 +18,7 @@ func TestGroupJoin(t *testing.T) {
 		func(outer int, inners []int) KeyValue[int, int] {
 			return KeyValue[int, int]{outer, len(inners)}
 		})
+	checkSizeHint(t, "GroupJoin", q, len(outer))
 
 	if !testQueryIteration(q, want) {
 		t.Errorf("FromSlice().GroupJoin()=%v expected %v", toSlice(q), want)

--- a/size_test.go
+++ b/size_test.go
@@ -50,14 +50,11 @@ func checkSizeHint[T any](t *testing.T, name string, q Query[T], want int) {
 	}
 }
 
-// TestSizeHint_Derived pins the operators whose output count follows exactly
-// from their input sizes.
 func TestSizeHint_Derived(t *testing.T) {
 	q := FromSlice(make([]int, 10))
 	checkSizeHint(t, "Take", q.Take(3), 3)
 	checkSizeHint(t, "Take past end", q.Take(50), 10)
 	checkSizeHint(t, "Skip", q.Skip(3), 7)
-	checkSizeHint(t, "Skip past end", q.Skip(50), 0)
 	checkSizeHint(t, "Skip negative", q.Skip(-5), 10)
 	checkSizeHint(t, "Concat", q.Concat(Range(0, 5)), 15)
 	checkSizeHint(t, "Append", q.Append(1), 11)
@@ -68,8 +65,6 @@ func TestSizeHint_Derived(t *testing.T) {
 	}), 4)
 }
 
-// TestSizeHint_Unknown pins the other direction: no operator may invent a size
-// for an input that carries none.
 func TestSizeHint_Unknown(t *testing.T) {
 	sized := FromSlice(make([]int, 10))
 	unsized := FromSeq(slices.Values(make([]int, 10)))
@@ -82,6 +77,8 @@ func TestSizeHint_Unknown(t *testing.T) {
 	checkSizeHint(t, "Prepend unsized", unsized.Prepend(1), 0)
 	checkSizeHint(t, "Take unsized", unsized.Take(3), 0)
 	checkSizeHint(t, "Skip unsized", unsized.Skip(3), 0)
+	// Zero cannot distinguish a known-empty result from an unknown size.
+	checkSizeHint(t, "Skip past end", sized.Skip(50), 0)
 	checkSizeHint(t, "DefaultIfEmpty unsized", unsized.DefaultIfEmpty(0), 0)
 	checkSizeHint(t, "Zip unsized", sized.Zip(unsized, func(a, b int) int {
 		return a + b

--- a/size_test.go
+++ b/size_test.go
@@ -1,10 +1,14 @@
 package linq
 
-import "testing"
+import (
+	"math"
+	"slices"
+	"testing"
+)
 
 // The size hint carried by Query is an invariant the compiler cannot check:
-// it may be propagated only by operators that emit exactly one element per
-// source element. These tests pin it in both directions.
+// it may be propagated only when an operator can derive its output count
+// exactly. These tests pin it in both directions.
 
 // TestSizeHint_ExactPreallocation catches an operator losing the hint: append
 // growth never lands on an arbitrary exact size (collecting 1000 elements by
@@ -37,4 +41,52 @@ func TestSizeHint_DroppedByFilters(t *testing.T) {
 	if cap(out) >= 100_000 {
 		t.Errorf("cap=%d: filtered query inherited the source's size hint", cap(out))
 	}
+}
+
+func checkSizeHint[T any](t *testing.T, name string, q Query[T], want int) {
+	t.Helper()
+	if got := q.size; got != want {
+		t.Errorf("%s size=%d expected %d", name, got, want)
+	}
+}
+
+// TestDerivedSizeHints pins the operators whose output count follows exactly
+// from their input sizes.
+func TestDerivedSizeHints(t *testing.T) {
+	q := FromSlice(make([]int, 10))
+	checkSizeHint(t, "Take", q.Take(3), 3)
+	checkSizeHint(t, "Take past end", q.Take(50), 10)
+	checkSizeHint(t, "Skip", q.Skip(3), 7)
+	checkSizeHint(t, "Skip past end", q.Skip(50), 0)
+	checkSizeHint(t, "Skip negative", q.Skip(-5), 10)
+	checkSizeHint(t, "Concat", q.Concat(Range(0, 5)), 15)
+	checkSizeHint(t, "Append", q.Append(1), 11)
+	checkSizeHint(t, "Prepend", q.Prepend(1), 11)
+	checkSizeHint(t, "DefaultIfEmpty", q.DefaultIfEmpty(0), 10)
+	checkSizeHint(t, "Zip", q.Zip(Range(0, 4), func(a, b int) int {
+		return a + b
+	}), 4)
+}
+
+// TestUnknownSizeHints pins the other direction: no operator may invent a size
+// for an input that carries none.
+func TestUnknownSizeHints(t *testing.T) {
+	sized := FromSlice(make([]int, 10))
+	unsized := FromSeq(slices.Values(make([]int, 10)))
+
+	checkSizeHint(t, "unsized source", unsized, 0)
+	checkSizeHint(t, "Concat unsized right", sized.Concat(unsized), 0)
+	checkSizeHint(t, "Concat unsized left", unsized.Concat(sized), 0)
+	checkSizeHint(t, "Append unsized", unsized.Append(1), 0)
+	checkSizeHint(t, "Append overflow", Repeat(0, math.MaxInt).Append(0), 0)
+	checkSizeHint(t, "Prepend unsized", unsized.Prepend(1), 0)
+	checkSizeHint(t, "Take unsized", unsized.Take(3), 0)
+	checkSizeHint(t, "Skip unsized", unsized.Skip(3), 0)
+	checkSizeHint(t, "DefaultIfEmpty unsized", unsized.DefaultIfEmpty(0), 0)
+	checkSizeHint(t, "Zip unsized", sized.Zip(unsized, func(a, b int) int {
+		return a + b
+	}), 0)
+	checkSizeHint(t, "Where", sized.Where(func(int) bool {
+		return true
+	}), 0)
 }

--- a/size_test.go
+++ b/size_test.go
@@ -50,9 +50,9 @@ func checkSizeHint[T any](t *testing.T, name string, q Query[T], want int) {
 	}
 }
 
-// TestDerivedSizeHints pins the operators whose output count follows exactly
+// TestSizeHint_Derived pins the operators whose output count follows exactly
 // from their input sizes.
-func TestDerivedSizeHints(t *testing.T) {
+func TestSizeHint_Derived(t *testing.T) {
 	q := FromSlice(make([]int, 10))
 	checkSizeHint(t, "Take", q.Take(3), 3)
 	checkSizeHint(t, "Take past end", q.Take(50), 10)
@@ -68,9 +68,9 @@ func TestDerivedSizeHints(t *testing.T) {
 	}), 4)
 }
 
-// TestUnknownSizeHints pins the other direction: no operator may invent a size
+// TestSizeHint_Unknown pins the other direction: no operator may invent a size
 // for an input that carries none.
-func TestUnknownSizeHints(t *testing.T) {
+func TestSizeHint_Unknown(t *testing.T) {
 	sized := FromSlice(make([]int, 10))
 	unsized := FromSeq(slices.Values(make([]int, 10)))
 

--- a/skip.go
+++ b/skip.go
@@ -14,6 +14,7 @@ func (q Query[T]) Skip(count int) Query[T] {
 				return yield(item)
 			})
 		},
+		size: max(q.size-max(count, 0), 0),
 	}
 }
 

--- a/take.go
+++ b/take.go
@@ -19,6 +19,7 @@ func (q Query[T]) Take(count int) Query[T] {
 				return n > 0
 			})
 		},
+		size: min(count, q.size),
 	}
 }
 

--- a/union.go
+++ b/union.go
@@ -15,30 +15,18 @@ func (q Query[T]) Union(q2 Query[T]) Query[T] {
 	return Query[T]{
 		Iterate: func(yield func(T) bool) {
 			set := newSeenSet[T]()
-			stopped := false
-
-			q.Iterate(func(item T) bool {
+			continuing := true
+			emit := func(item T) bool {
 				if set.add(item) {
-					if !yield(item) {
-						stopped = true
-						return false
-					}
+					continuing = yield(item)
 				}
-				return true
-			})
-
-			if stopped {
-				return
+				return continuing
 			}
 
-			q2.Iterate(func(item T) bool {
-				if set.add(item) {
-					if !yield(item) {
-						return false
-					}
-				}
-				return true
-			})
+			q.Iterate(emit)
+			if continuing {
+				q2.Iterate(emit)
+			}
 		},
 	}
 }
@@ -53,34 +41,20 @@ func (q Query[T]) UnionBy[TKey comparable](q2 Query[T], selector func(T) TKey) Q
 	return Query[T]{
 		Iterate: func(yield func(T) bool) {
 			set := make(map[TKey]struct{})
-			stopped := false
-
-			q.Iterate(func(item T) bool {
+			continuing := true
+			emit := func(item T) bool {
 				key := selector(item)
 				if _, seen := set[key]; !seen {
 					set[key] = struct{}{}
-					if !yield(item) {
-						stopped = true
-						return false
-					}
+					continuing = yield(item)
 				}
-				return true
-			})
-
-			if stopped {
-				return
+				return continuing
 			}
 
-			q2.Iterate(func(item T) bool {
-				key := selector(item)
-				if _, seen := set[key]; !seen {
-					set[key] = struct{}{}
-					if !yield(item) {
-						return false
-					}
-				}
-				return true
-			})
+			q.Iterate(emit)
+			if continuing {
+				q2.Iterate(emit)
+			}
 		},
 	}
 }

--- a/union_test.go
+++ b/union_test.go
@@ -53,24 +53,38 @@ func TestUnion_Abort(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			q := FromSlice(input1).Union(FromSlice(input2))
+	// UnionBy with an identity selector must abort exactly like Union: both
+	// carry the stop across the two source iterations through one closure.
+	unions := []struct {
+		name string
+		fn   func(Query[int], Query[int]) Query[int]
+	}{
+		{"Union", Query[int].Union},
+		{"UnionBy", func(q, q2 Query[int]) Query[int] {
+			return q.UnionBy(q2, func(v int) int { return v })
+		}},
+	}
 
-			var results []int
-			i := 0
-			q.Iterate(func(v int) bool {
-				results = append(results, v)
-				i++
-				if i >= tt.abortIndex {
-					return false // simulate early termination
+	for _, u := range unions {
+		for _, tt := range tests {
+			t.Run(u.name+"/"+tt.name, func(t *testing.T) {
+				q := u.fn(FromSlice(input1), FromSlice(input2))
+
+				var results []int
+				i := 0
+				q.Iterate(func(v int) bool {
+					results = append(results, v)
+					i++
+					if i >= tt.abortIndex {
+						return false // simulate early termination
+					}
+					return true
+				})
+
+				if !slices.Equal(results, tt.want) {
+					t.Errorf("got %v, want %v", results, tt.want)
 				}
-				return true
 			})
-
-			if !slices.Equal(results, tt.want) {
-				t.Errorf("%s: got %v, want %v", tt.name, results, tt.want)
-			}
-		})
+		}
 	}
 }

--- a/union_test.go
+++ b/union_test.go
@@ -53,8 +53,6 @@ func TestUnion_Abort(t *testing.T) {
 		},
 	}
 
-	// UnionBy with an identity selector must abort exactly like Union: both
-	// carry the stop across the two source iterations through one closure.
 	unions := []struct {
 		name string
 		fn   func(Query[int], Query[int]) Query[int]

--- a/zip.go
+++ b/zip.go
@@ -29,5 +29,6 @@ func (q Query[T]) Zip[TSecond, TResult any](q2 Query[TSecond],
 				return yield(resultSelector(item, item2))
 			})
 		},
+		size: min(q.size, q2.size),
 	}
 }


### PR DESCRIPTION
## Summary

- propagate exact size hints through operators whose output cardinality can be derived
- fall back to an unknown hint when an input size is unknown or addition overflows
- cover derived, unknown, overflow, and `GroupJoin` cases

## Why

This allows `ToSlice` to preallocate correctly through more query chains without changing iteration semantics. Operators with data-dependent cardinality continue to drop the hint.