### PR TITLE
feat: add .NET 6-11 LINQ operators

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -50,7 +50,7 @@ than the `…T` API was.
 | `GroupJoin(...)` | `GroupJoin(inner Query[TInner], func(T) TKey, func(TInner) TKey, func(T, []TInner) TResult) Query[TResult]` |
 | `GroupBy(keySel, elemSel)` | `GroupBy(func(T) TKey, func(T) TElement) Query[Group[TKey, TElement]]`; groups now come out in first-seen key order (was unspecified map order) |
 | `Zip(q2, result)` | `Zip(q2 Query[TSecond], func(T, TSecond) TResult) Query[TResult]` |
-| `OrderBy(func(any) any)` | `OrderBy(func(T) TKey)` with `TKey cmp.Ordered` — same for `OrderByDescending`, `ThenBy`, `ThenByDescending`. Each level may use a different key type. `bool` keys are no longer supported: map them to `int` |
+| `OrderBy(func(any) any)` | `OrderBy(func(T) TKey)` with `TKey cmp.Ordered` — same for `OrderByDescending`, `ThenBy`, `ThenByDescending`. Each level may use a different key type. `bool` keys are no longer supported: map them to `int`. The sort is now stable, matching .NET: elements with equal keys keep their input order, at the cost of O(n log²n) comparisons in the worst case |
 | `Sort(less func(i, j any) bool)` | `Sort(less func(i, j T) bool)` |
 | `Distinct()`, `Union(q2)`, `Except(q2)`, `Intersect(q2)`, `Contains(v)`, `SequenceEqual(q2)` | unchanged shape; elements of basic comparable kinds (integers, floats, complex, strings, booleans) are tracked and compared through strongly-typed sets with no boxing. Other element types fall back to boxed comparison at runtime (as in v4) — for those, the `By` variants with a `comparable` key remain the typed fast path |
 | `DistinctBy(func(any) any)` | `DistinctBy(func(T) TKey)` with `TKey comparable` — same for `ExceptBy`, `IntersectBy`, and **new** `UnionBy` |

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -19,7 +19,7 @@ already typed and usually work as-is on the base method name.
 | `KeyValue` (`Key`, `Value` are `any`) | `KeyValue[TKey comparable, TValue any]` |
 | `Group` (`Key any`, `Group []any`) | `Group[TKey comparable, TElement any]` |
 | `Iterable` (`Iterate() iter.Seq[any]`) | *removed* — pass your collection's iterator to `FromSeq(c.Iterate())` |
-| `Comparable` (`CompareTo`) | *removed* — `OrderBy`/`ThenBy` keys must satisfy `cmp.Ordered`; use `Sort(less)` for custom comparison logic |
+| `Comparable` (`CompareTo`) | *removed* — `OrderBy`/`ThenBy` keys must satisfy `cmp.Ordered`; use `OrderWith(compare)` for custom comparison logic, which like v4 still chains into `ThenBy`. `Sort(less)` is unstable and does not chain |
 
 ## Constructors
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,8 @@ each iteration.
 All five joins follow .NET in ignoring nil keys: a nil key never matches, not
 even another nil key. `LeftJoin` and `RightJoin` still emit a nil-key element
 when it belongs to the retained side; `GroupJoin` emits a nil-key outer element
-with an empty group.
+with an empty group. An `any` key may hold a typed nil, which joins treat as nil;
+other non-comparable dynamic values may panic when used as lookup keys.
 
 ## .NET 11 Operators
 

--- a/README.md
+++ b/README.md
@@ -166,9 +166,10 @@ for v := range q.Iterate {
 
 ## Data Source Constructors
 
-Each constructor is typed for its specific input, and the element type of the
-resulting query is inferred from the argument:
+Each constructor is typed. `Empty` takes an explicit type argument; the other
+constructors take their element type from their arguments:
 
+- `Empty[T]` — creates an empty query of the specified element type.
 - `FromSlice` — creates a query from a slice.
 - `FromMap` — creates a `Query[KeyValue[TKey, TValue]]` from a map.
 - `FromChannel` — creates a query from a channel.
@@ -248,7 +249,8 @@ highlights:
   methods are now just as clean and much faster.
 * Element-returning terminals (`First`, `Last`, `Single`, `Aggregate`,
   `Min`, `Max`, …) return `(T, bool)` instead of a nil-able `any`.
-* `Min`, `Max`, `Sum`, `Average`, `ToMap` are package-level functions
+* `Min`, `Max`, `Sum`, `Average`, `ToMap`, and `ToHashSet` are package-level
+  functions
   (their constraints depend on the element type); chainable `MinBy`,
   `MaxBy`, `SumBy`, `AverageBy`, `ToMapBy` methods are available.
 * `ToSlice()` returns `[]T` instead of filling a pointer argument.
@@ -273,6 +275,7 @@ v5.0.0 (2026-08-21)
     cmp.Ordered (use Sort for custom comparisons).
   - GroupBy yields groups in first-seen key order (deterministic).
   - Added FromSeq to adapt any iter.Seq[T].
+  - Added Empty and ToHashSet.
   - Added .NET 6 operators: Chunk, index/range operations, SkipLast, TakeLast,
     comparer-based extrema, and Zip3.
   - Added .NET 9 operators: CountBy, both AggregateBy seed forms, and Index.

--- a/README.md
+++ b/README.md
@@ -182,71 +182,55 @@ constructors take their element type from their arguments:
 The runtime-reflection based `From(any)` constructor from v4 has been removed:
 in a fully-typed API the element type must be known at the call site.
 
-## .NET 6 Operators
+## Go API notes
 
-v5 includes `ElementAt(Position)`, `SkipLast`, `TakeLast`, `TakeRange`, `Zip3`,
-`MinWith`/`MaxWith`, and `MinByWith`/`MaxByWith`. Construct indices with
-`PositionFromStart(n)` or `PositionFromEnd(n)`.
-`Chunk` is a package-level function (`Chunk(query, size)`) because the current
-Go compiler rejects `Query[T].Chunk() Query[[]T]` as an instantiation cycle.
-The .NET explicit-default overloads are represented by Go's existing
-`(value, ok)` return convention instead of separate methods.
+Where a direct translation from .NET was not possible:
 
-## .NET 7 Operators
+- Comparer overloads become `…With` methods (`OrderWith`, `MinWith`,
+  `MaxByWith`, …), whose `compare` argument follows the `cmp.Compare`
+  convention. The explicit-default overloads need no counterpart: Go's
+  `(value, ok)` return already covers them.
+- Index and range arguments are a `Position`, built with `FromStart(n)` or
+  `FromEnd(n)`: `q.ElementAt(FromEnd(1))`,
+  `q.TakeRange(FromStart(2), FromEnd(1))`.
+- Joins ignore nil keys, matching .NET: a nil key never matches, not even
+  another nil key. An `any` key holding a typed nil counts as nil; one holding
+  a non-comparable value panics, as any Go map key would.
 
-v5 includes `Order`/`OrderDescending` and `OrderWith`/`OrderDescendingWith`.
-`Order` and `OrderDescending` are package-level functions (`Order(query)`)
-because they constrain the element type to `cmp.Ordered`. The comparer
-overloads become the `OrderWith`/`OrderDescendingWith` methods instead, which
-place no constraint on the element type; their `compare` argument follows the
-`cmp.Compare` convention, like `MinWith`/`MaxWith`.
+Some operators are package-level functions rather than methods. Each has a
+chainable equivalent:
 
-All four are stable and return an `OrderedQuery` that `ThenBy` and
-`ThenByDescending` can refine further. `Sort` also takes arbitrary comparison
-logic, but it is unstable and does not chain.
+| package-level | chainable |
+|---|---|
+| `Min(q)`, `Max(q)` | `MinBy`/`MaxBy`, `MinWith`/`MaxWith`, `MinByWith`/`MaxByWith` |
+| `Sum(q)`, `Average(q)` | `SumBy`, `AverageBy` |
+| `Order(q)`, `OrderDescending(q)` | `OrderBy`/`OrderByDescending`, `OrderWith`/`OrderDescendingWith` |
+| `ToMap(q)` | `ToMapBy` |
+| `ToHashSet(q)` | `ToHashSetBy` |
+| `Chunk(q, size)` | `ChunkBy` |
+| `Index(q)` | `SelectIndexed` |
 
-## .NET 9 Operators
-
-v5 includes `CountBy`, `AggregateBy`, `AggregateByWithSeedSelector`, and
-`Index`. The first three yield `KeyValue` results in the order each key first
-appears. `Index(query)` yields `KeyValue` values whose `Key` is the index and
-`Value` is the item; like `Chunk`, it is a package-level function because a
-direct `Query[T].Index() Query[KeyValue[int, T]]` method causes an
-instantiation cycle in the current Go compiler.
-
-## .NET 10 Operators
-
-v5 includes `LeftJoin`, `RightJoin`, `Sequence`, `InfiniteSequence`, and
-`Shuffle`. `Sequence` and `InfiniteSequence` support every type in the existing
-`Number` constraint. Outer joins pass the zero value for an unmatched element.
-`Shuffle` uses a non-cryptographically-secure random source and reshuffles on
-each iteration.
-
-All five joins follow .NET in ignoring nil keys: a nil key never matches, not
-even another nil key. `LeftJoin` and `RightJoin` still emit a nil-key element
-when it belongs to the retained side; `GroupJoin` emits a nil-key outer element
-with an empty group. An `any` key may hold a typed nil, which joins treat as nil;
-other non-comparable dynamic values may panic when used as lookup keys.
-
-## .NET 11 Operators
-
-v5 includes `FullJoin`. It emits matches and unmatched outer elements in outer
-order, then unmatched inner groups in first-seen key order. The missing side is
-passed to the result selector as its zero value. Nil-key elements never match
-but are retained as unmatched elements from both sides.
-
-The .NET 11 overloads that omit the result selector and return tuples have no
-Go equivalent, so they are not included.
+The first five rows constrain the element type — ordered, numeric, `KeyValue`,
+comparable — and a method cannot add a constraint to its receiver's type
+parameter. The last two would return `Query[[]T]` and `Query[KeyValue[int, T]]`,
+which the compiler rejects as a recursive instantiation. Either way the method
+form needs a selector or comparator argument to pin its type parameter, which is
+what the right-hand column supplies.
 
 ## Performance
 
-v5 eliminates the three taxes the type-erased v4 API paid on every element:
-interface boxing, type assertions, and reflection. Per-element work in a v5
-chain is just typed closure calls; the only allocations are the fixed closure
-captures made when the query is constructed.
-The lone exception is a join keyed on an interface type: separating a typed
-nil pointer from a nil interface needs the dynamic value, so that key type
-alone pays for reflection per element.
+v5 removes interface boxing, type assertions, and reflection from ordinary
+typed pipelines. Stateless streaming operators process each element through
+typed closure calls without per-element allocations in the library.
+
+Stateful operators allocate working storage during iteration. `Distinct`,
+`Union`, `Except`, `Intersect`, and their `By` variants keep sets of seen keys;
+the variants without a key selector may also box non-basic element types.
+`SkipLast` and `Chunk` keep bounded buffers. The ordering operators, `Reverse`,
+`Shuffle`, `TakeLast`, `GroupBy`, `CountBy`, `AggregateBy`, and the joins buffer
+the data they need before or while yielding results. A join keyed on an
+interface type also uses reflection per element to distinguish a typed nil
+pointer from a nil interface.
 
 Measured on Apple M5 Pro with go1.27, 1M-element `[]int` (100k structs for
 the projection case):
@@ -273,15 +257,32 @@ highlights:
   methods are now just as clean and much faster.
 * Element-returning terminals (`First`, `Last`, `Single`, `Aggregate`,
   `Min`, `Max`, …) return `(T, bool)` instead of a nil-able `any`.
-* `Min`, `Max`, `Sum`, `Average`, `Order`, `OrderDescending`, `ToMap`, and
-  `ToHashSet` are package-level functions
-  (their constraints depend on the element type); chainable `MinBy`,
-  `MaxBy`, `SumBy`, `AverageBy`, `ToMapBy` methods are available.
+* `Min`, `Max`, `Sum`, `Average`, `ToMap` and several others are package-level
+  functions; [Go API notes](#go-api-notes) lists them all with the chainable
+  equivalent of each.
 * `ToSlice()` returns `[]T` instead of filling a pointer argument.
 
 ## Release Notes
 
 ```text
+v5.1.0 (unreleased)
+* Added Empty, ToHashSet and ToHashSetBy.
+* Added .NET 6 operators: Chunk, SkipLast, TakeLast, position/range operations
+  (ElementAt, TakeRange), comparer-based extrema, and Zip3. ChunkBy projects
+  each chunk, so unlike Chunk it can be a method and stay in a chain.
+* Added .NET 7 operators: Order/OrderDescending and the comparer-based
+  OrderWith/OrderDescendingWith variants. All four are stable and chainable
+  with ThenBy; OrderWith replaces Sort as the way to order by a custom
+  comparison.
+* Added .NET 9 operators: CountBy, both AggregateBy seed forms, and Index.
+* Added .NET 10 operators: LeftJoin, RightJoin, Sequence, InfiniteSequence,
+  and Shuffle.
+* Added the .NET 11 FullJoin operator.
+* OrderBy, OrderByDescending, ThenBy and ThenByDescending are now stable,
+  matching .NET LINQ; Sort keeps its existing unstable behavior.
+* Fixed Join and GroupJoin matching nil keys against each other. Like .NET and
+  the new outer joins, a nil key now takes no part in a join.
+
 v5.0.0 (2026-08-21)
 * Breaking change: COMPLETE REWRITE on Go 1.27 generic methods.
   - Query is now the generic Query[T]; operator callbacks are fully typed.
@@ -296,25 +297,9 @@ v5.0.0 (2026-08-21)
     MinBy/MaxBy/SumBy/AverageBy/ToMapBy/UnionBy methods.
   - ToSlice() returns []T; ToMap/ToMapBy return maps.
   - Removed Comparable interface; OrderBy/ThenBy keys must satisfy
-    cmp.Ordered (use OrderWith for custom comparisons).
+    cmp.Ordered (use Sort for custom comparisons).
   - GroupBy yields groups in first-seen key order (deterministic).
   - Added FromSeq to adapt any iter.Seq[T].
-  - Added Empty and ToHashSet.
-  - Added .NET 6 operators: Chunk, index/range operations, SkipLast, TakeLast,
-    comparer-based extrema, and Zip3.
-  - Added .NET 7 operators: Order/OrderDescending and the comparer-based
-    OrderWith/OrderDescendingWith variants. All four are stable and chainable
-    with ThenBy.
-  - OrderBy, OrderByDescending, ThenBy and ThenByDescending are now stable,
-    matching .NET LINQ; Sort keeps its existing unstable behavior.
-  - Added .NET 9 operators: CountBy, both AggregateBy seed forms, and Index.
-  - Added .NET 10 operators: LeftJoin, RightJoin, Sequence, InfiniteSequence,
-    and Shuffle.
-  - Added the .NET 11 FullJoin operator.
-  - Changed Join and GroupJoin to ignore nil keys, matching .NET and the new
-    outer joins. Elements with a nil key previously matched each other.
-  - Renamed the range/index helper and constructors from Index to Position to
-    make room for the Index operator.
   - 5-15x faster than v4; allocations drop from O(n) to O(1) per query.
 
 v4.0.0 (2025-10-12)

--- a/README.md
+++ b/README.md
@@ -192,6 +192,19 @@ Go compiler rejects `Query[T].Chunk() Query[[]T]` as an instantiation cycle.
 The .NET explicit-default overloads are represented by Go's existing
 `(value, ok)` return convention instead of separate methods.
 
+## .NET 7 Operators
+
+v5 includes `Order`/`OrderDescending` and `OrderWith`/`OrderDescendingWith`.
+`Order` and `OrderDescending` are package-level functions (`Order(query)`)
+because they constrain the element type to `cmp.Ordered`. The comparer
+overloads become the `OrderWith`/`OrderDescendingWith` methods instead, which
+place no constraint on the element type; their `compare` argument follows the
+`cmp.Compare` convention, like `MinWith`/`MaxWith`.
+
+All four are stable and return an `OrderedQuery` that `ThenBy` and
+`ThenByDescending` can refine further. `Sort` also takes arbitrary comparison
+logic, but it is unstable and does not chain.
+
 ## .NET 9 Operators
 
 v5 includes `CountBy`, `AggregateBy`, `AggregateByWithSeedSelector`, and
@@ -249,8 +262,8 @@ highlights:
   methods are now just as clean and much faster.
 * Element-returning terminals (`First`, `Last`, `Single`, `Aggregate`,
   `Min`, `Max`, …) return `(T, bool)` instead of a nil-able `any`.
-* `Min`, `Max`, `Sum`, `Average`, `ToMap`, and `ToHashSet` are package-level
-  functions
+* `Min`, `Max`, `Sum`, `Average`, `Order`, `OrderDescending`, `ToMap`, and
+  `ToHashSet` are package-level functions
   (their constraints depend on the element type); chainable `MinBy`,
   `MaxBy`, `SumBy`, `AverageBy`, `ToMapBy` methods are available.
 * `ToSlice()` returns `[]T` instead of filling a pointer argument.
@@ -272,12 +285,17 @@ v5.0.0 (2026-08-21)
     MinBy/MaxBy/SumBy/AverageBy/ToMapBy/UnionBy methods.
   - ToSlice() returns []T; ToMap/ToMapBy return maps.
   - Removed Comparable interface; OrderBy/ThenBy keys must satisfy
-    cmp.Ordered (use Sort for custom comparisons).
+    cmp.Ordered (use OrderWith for custom comparisons).
   - GroupBy yields groups in first-seen key order (deterministic).
   - Added FromSeq to adapt any iter.Seq[T].
   - Added Empty and ToHashSet.
   - Added .NET 6 operators: Chunk, index/range operations, SkipLast, TakeLast,
     comparer-based extrema, and Zip3.
+  - Added .NET 7 operators: Order/OrderDescending and the comparer-based
+    OrderWith/OrderDescendingWith variants. All four are stable and chainable
+    with ThenBy.
+  - OrderBy, OrderByDescending, ThenBy and ThenByDescending are now stable,
+    matching .NET LINQ; Sort keeps its existing unstable behavior.
   - Added .NET 9 operators: CountBy, both AggregateBy seed forms, and Index.
   - Added .NET 10 operators: LeftJoin, RightJoin, Sequence, InfiniteSequence,
     and Shuffle.

--- a/README.md
+++ b/README.md
@@ -222,10 +222,20 @@ v5 includes `LeftJoin`, `RightJoin`, `Sequence`, `InfiniteSequence`, and
 `Shuffle` uses a non-cryptographically-secure random source and reshuffles on
 each iteration.
 
-All four joins follow .NET in ignoring nil keys: a nil key never matches, not
+All five joins follow .NET in ignoring nil keys: a nil key never matches, not
 even another nil key. `LeftJoin` and `RightJoin` still emit a nil-key element
 when it belongs to the retained side; `GroupJoin` emits a nil-key outer element
 with an empty group.
+
+## .NET 11 Operators
+
+v5 includes `FullJoin`. It emits matches and unmatched outer elements in outer
+order, then unmatched inner groups in first-seen key order. The missing side is
+passed to the result selector as its zero value. Nil-key elements never match
+but are retained as unmatched elements from both sides.
+
+The .NET 11 overloads that omit the result selector and return tuples have no
+Go equivalent, so they are not included.
 
 ## Performance
 
@@ -299,6 +309,7 @@ v5.0.0 (2026-08-21)
   - Added .NET 9 operators: CountBy, both AggregateBy seed forms, and Index.
   - Added .NET 10 operators: LeftJoin, RightJoin, Sequence, InfiniteSequence,
     and Shuffle.
+  - Added the .NET 11 FullJoin operator.
   - Changed Join and GroupJoin to ignore nil keys, matching .NET and the new
     outer joins. Elements with a nil key previously matched each other.
   - Renamed the range/index helper and constructors from Index to Position to

--- a/README.md
+++ b/README.md
@@ -183,13 +183,22 @@ in a fully-typed API the element type must be known at the call site.
 
 ## .NET 6 Operators
 
-v5 includes `ElementAt(Index)`, `SkipLast`, `TakeLast`, `TakeRange`, `Zip3`,
+v5 includes `ElementAt(Position)`, `SkipLast`, `TakeLast`, `TakeRange`, `Zip3`,
 `MinWith`/`MaxWith`, and `MinByWith`/`MaxByWith`. Construct indices with
-`IndexFromStart(n)` or `IndexFromEnd(n)`.
+`PositionFromStart(n)` or `PositionFromEnd(n)`.
 `Chunk` is a package-level function (`Chunk(query, size)`) because the current
 Go compiler rejects `Query[T].Chunk() Query[[]T]` as an instantiation cycle.
 The .NET explicit-default overloads are represented by Go's existing
 `(value, ok)` return convention instead of separate methods.
+
+## .NET 9 Operators
+
+v5 includes `CountBy`, `AggregateBy`, `AggregateByWithSeedSelector`, and
+`Index`. The first three yield `KeyValue` results in the order each key first
+appears. `Index(query)` yields `KeyValue` values whose `Key` is the index and
+`Value` is the item; like `Chunk`, it is a package-level function because a
+direct `Query[T].Index() Query[KeyValue[int, T]]` method causes an
+instantiation cycle in the current Go compiler.
 
 ## Performance
 
@@ -250,6 +259,9 @@ v5.0.0 (2026-08-21)
   - Added FromSeq to adapt any iter.Seq[T].
   - Added .NET 6 operators: Chunk, index/range operations, SkipLast, TakeLast,
     comparer-based extrema, and Zip3.
+  - Added .NET 9 operators: CountBy, both AggregateBy seed forms, and Index.
+  - Renamed the range/index helper and constructors from Index to Position to
+    make room for the Index operator.
   - 5-15x faster than v4; allocations drop from O(n) to O(1) per query.
 
 v4.0.0 (2025-10-12)

--- a/README.md
+++ b/README.md
@@ -181,6 +181,16 @@ resulting query is inferred from the argument:
 The runtime-reflection based `From(any)` constructor from v4 has been removed:
 in a fully-typed API the element type must be known at the call site.
 
+## .NET 6 Operators
+
+v5 includes `ElementAt(Index)`, `SkipLast`, `TakeLast`, `TakeRange`, `Zip3`,
+`MinWith`/`MaxWith`, and `MinByWith`/`MaxByWith`. Construct indices with
+`IndexFromStart(n)` or `IndexFromEnd(n)`.
+`Chunk` is a package-level function (`Chunk(query, size)`) because the current
+Go compiler rejects `Query[T].Chunk() Query[[]T]` as an instantiation cycle.
+The .NET explicit-default overloads are represented by Go's existing
+`(value, ok)` return convention instead of separate methods.
+
 ## Performance
 
 v5 eliminates the three taxes the type-erased v4 API paid on every element:
@@ -238,6 +248,8 @@ v5.0.0 (2026-08-21)
     cmp.Ordered (use Sort for custom comparisons).
   - GroupBy yields groups in first-seen key order (deterministic).
   - Added FromSeq to adapt any iter.Seq[T].
+  - Added .NET 6 operators: Chunk, index/range operations, SkipLast, TakeLast,
+    comparer-based extrema, and Zip3.
   - 5-15x faster than v4; allocations drop from O(n) to O(1) per query.
 
 v4.0.0 (2025-10-12)

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ resulting query is inferred from the argument:
 - `FromString` — creates a `Query[rune]` from a string.
 - `FromSeq` — creates a query from any standard `iter.Seq[T]` iterator,
   including custom collections that expose an iterator method.
-- `Range`, `Repeat` — generate sequences.
+- `Range`, `Repeat`, `Sequence`, `InfiniteSequence` — generate sequences.
 
 The runtime-reflection based `From(any)` constructor from v4 has been removed:
 in a fully-typed API the element type must be known at the call site.
@@ -200,12 +200,28 @@ appears. `Index(query)` yields `KeyValue` values whose `Key` is the index and
 direct `Query[T].Index() Query[KeyValue[int, T]]` method causes an
 instantiation cycle in the current Go compiler.
 
+## .NET 10 Operators
+
+v5 includes `LeftJoin`, `RightJoin`, `Sequence`, `InfiniteSequence`, and
+`Shuffle`. `Sequence` and `InfiniteSequence` support every type in the existing
+`Number` constraint. Outer joins pass the zero value for an unmatched element.
+`Shuffle` uses a non-cryptographically-secure random source and reshuffles on
+each iteration.
+
+All four joins follow .NET in ignoring nil keys: a nil key never matches, not
+even another nil key. `LeftJoin` and `RightJoin` still emit a nil-key element
+when it belongs to the retained side; `GroupJoin` emits a nil-key outer element
+with an empty group.
+
 ## Performance
 
 v5 eliminates the three taxes the type-erased v4 API paid on every element:
 interface boxing, type assertions, and reflection. Per-element work in a v5
 chain is just typed closure calls; the only allocations are the fixed closure
 captures made when the query is constructed.
+The lone exception is a join keyed on an interface type: separating a typed
+nil pointer from a nil interface needs the dynamic value, so that key type
+alone pays for reflection per element.
 
 Measured on Apple M5 Pro with go1.27, 1M-element `[]int` (100k structs for
 the projection case):
@@ -260,6 +276,10 @@ v5.0.0 (2026-08-21)
   - Added .NET 6 operators: Chunk, index/range operations, SkipLast, TakeLast,
     comparer-based extrema, and Zip3.
   - Added .NET 9 operators: CountBy, both AggregateBy seed forms, and Index.
+  - Added .NET 10 operators: LeftJoin, RightJoin, Sequence, InfiniteSequence,
+    and Shuffle.
+  - Changed Join and GroupJoin to ignore nil keys, matching .NET and the new
+    outer joins. Elements with a nil key previously matched each other.
   - Renamed the range/index helper and constructors from Index to Position to
     make room for the Index operator.
   - 5-15x faster than v4; allocations drop from O(n) to O(1) per query.

--- a/aggregate.go
+++ b/aggregate.go
@@ -83,3 +83,97 @@ func (q Query[T]) AggregateWithSeedBy[TAccumulate, TResult any](seed TAccumulate
 
 	return resultSelector(result)
 }
+
+// CountBy returns the number of elements for each selected key. Results are
+// ordered by the key's first appearance in the source.
+//
+// CountBy is a generic method: the key type TKey is inferred from the
+// keySelector function. The key type TKey must be comparable.
+func (q Query[T]) CountBy[TKey comparable](keySelector func(T) TKey) Query[KeyValue[TKey, int]] {
+	// Keep this loop specialized: delegating to aggregateBy adds a closure call
+	// per element and two allocations per query.
+	return Query[KeyValue[TKey, int]]{
+		Iterate: func(yield func(KeyValue[TKey, int]) bool) {
+			index := make(map[TKey]int)
+			var counts []KeyValue[TKey, int]
+
+			q.Iterate(func(item T) bool {
+				key := keySelector(item)
+				i, exists := index[key]
+				if !exists {
+					i = len(counts)
+					index[key] = i
+					counts = append(counts, KeyValue[TKey, int]{Key: key})
+				}
+				counts[i].Value++
+				return true
+			})
+
+			for _, count := range counts {
+				if !yield(count) {
+					return
+				}
+			}
+		},
+	}
+}
+
+// AggregateBy applies an accumulator to elements grouped by a selected key.
+// Each key starts with seed, and results are ordered by the key's first
+// appearance in the source.
+//
+// AggregateBy is a generic method: the key type TKey is inferred from the
+// keySelector function and the accumulator type TAccumulate from the seed
+// value. The key type TKey must be comparable.
+func (q Query[T]) AggregateBy[TKey comparable, TAccumulate any](keySelector func(T) TKey,
+	seed TAccumulate,
+	f func(accumulator TAccumulate, item T) TAccumulate) Query[KeyValue[TKey, TAccumulate]] {
+	return aggregateBy(q, keySelector, func(TKey) TAccumulate { return seed }, f)
+}
+
+// AggregateByWithSeedSelector applies an accumulator to elements grouped by a
+// selected key. seedSelector supplies the initial accumulator once per key,
+// and results are ordered by the key's first appearance in the source.
+//
+// AggregateByWithSeedSelector is a generic method: the key type TKey is
+// inferred from the keySelector function and the accumulator type TAccumulate
+// from the seedSelector function. The key type TKey must be comparable.
+func (q Query[T]) AggregateByWithSeedSelector[TKey comparable, TAccumulate any](
+	keySelector func(T) TKey,
+	seedSelector func(TKey) TAccumulate,
+	f func(accumulator TAccumulate, item T) TAccumulate) Query[KeyValue[TKey, TAccumulate]] {
+	return aggregateBy(q, keySelector, seedSelector, f)
+}
+
+func aggregateBy[T any, TKey comparable, TAccumulate any](q Query[T],
+	keySelector func(T) TKey,
+	seedSelector func(TKey) TAccumulate,
+	f func(TAccumulate, T) TAccumulate) Query[KeyValue[TKey, TAccumulate]] {
+	return Query[KeyValue[TKey, TAccumulate]]{
+		Iterate: func(yield func(KeyValue[TKey, TAccumulate]) bool) {
+			index := make(map[TKey]int)
+			var aggregates []KeyValue[TKey, TAccumulate]
+
+			q.Iterate(func(item T) bool {
+				key := keySelector(item)
+				i, exists := index[key]
+				if !exists {
+					i = len(aggregates)
+					index[key] = i
+					aggregates = append(aggregates, KeyValue[TKey, TAccumulate]{
+						Key:   key,
+						Value: seedSelector(key),
+					})
+				}
+				aggregates[i].Value = f(aggregates[i].Value, item)
+				return true
+			})
+
+			for _, aggregate := range aggregates {
+				if !yield(aggregate) {
+					return
+				}
+			}
+		},
+	}
+}

--- a/aggregate.go
+++ b/aggregate.go
@@ -90,8 +90,7 @@ func (q Query[T]) AggregateWithSeedBy[TAccumulate, TResult any](seed TAccumulate
 // CountBy is a generic method: the key type TKey is inferred from the
 // keySelector function. The key type TKey must be comparable.
 func (q Query[T]) CountBy[TKey comparable](keySelector func(T) TKey) Query[KeyValue[TKey, int]] {
-	// Keep this loop specialized: delegating to aggregateBy adds a closure call
-	// per element and two allocations per query.
+	// Keep this loop specialized to avoid an extra closure call per element.
 	return Query[KeyValue[TKey, int]]{
 		Iterate: func(yield func(KeyValue[TKey, int]) bool) {
 			index := make(map[TKey]int)

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -1,6 +1,7 @@
 package linq
 
 import (
+	"slices"
 	"strings"
 	"testing"
 )
@@ -80,5 +81,107 @@ func TestAggregateWithSeedBy(t *testing.T) {
 
 	if r != want {
 		t.Errorf("FromSlice(%v).AggregateWithSeedBy()=%v expected %v", input, r, want)
+	}
+}
+
+func TestCountBy(t *testing.T) {
+	input := []string{"apple", "banana", "apricot", "blueberry", "avocado", "cherry"}
+	want := []KeyValue[byte, int]{
+		{Key: 'a', Value: 3},
+		{Key: 'b', Value: 2},
+		{Key: 'c', Value: 1},
+	}
+
+	q := FromSlice(input).CountBy(func(item string) byte { return item[0] })
+	if !testQueryIteration(q, want) {
+		t.Errorf("CountBy()=%v expected %v", q.ToSlice(), want)
+	}
+	if got := FromSlice([]int{}).CountBy(func(item int) int { return item }).ToSlice(); got != nil {
+		t.Errorf("CountBy(empty)=%v expected nil", got)
+	}
+}
+
+func TestAggregateBy(t *testing.T) {
+	type score struct {
+		id    string
+		value int
+	}
+	input := []score{{"0", 42}, {"1", 5}, {"2", 4}, {"1", 10}, {"0", 25}}
+	want := []KeyValue[string, int]{
+		{Key: "0", Value: 67},
+		{Key: "1", Value: 15},
+		{Key: "2", Value: 4},
+	}
+
+	q := FromSlice(input).AggregateBy(
+		func(item score) string { return item.id },
+		0,
+		func(total int, item score) int { return total + item.value },
+	)
+	if !testQueryIteration(q, want) {
+		t.Errorf("AggregateBy()=%v expected %v", q.ToSlice(), want)
+	}
+	if got := FromSlice([]int{}).AggregateBy(
+		func(item int) int { return item },
+		0,
+		func(total, item int) int { return total + item },
+	).ToSlice(); got != nil {
+		t.Errorf("AggregateBy(empty)=%v expected nil", got)
+	}
+}
+
+func TestAggregateByWithSeedSelector(t *testing.T) {
+	type item struct {
+		key   string
+		value int
+	}
+	seedCalls := make(map[string]int)
+	q := FromSlice([]item{{"a", 1}, {"bb", 2}, {"a", 3}}).AggregateByWithSeedSelector(
+		func(item item) string { return item.key },
+		func(key string) int {
+			seedCalls[key]++
+			return len(key)
+		},
+		func(total int, item item) int { return total + item.value },
+	)
+
+	want := []KeyValue[string, int]{{Key: "a", Value: 5}, {Key: "bb", Value: 4}}
+	if got := q.ToSlice(); !slices.Equal(got, want) {
+		t.Errorf("AggregateByWithSeedSelector()=%v expected %v", got, want)
+	}
+	for _, key := range []string{"a", "bb"} {
+		if seedCalls[key] != 1 {
+			t.Errorf("seedSelector called %d times for %q expected 1", seedCalls[key], key)
+		}
+	}
+}
+
+func TestCountByConsumesSourceBeforeYielding(t *testing.T) {
+	pulled := 0
+	q := FromSlice([]int{1, 2, 3, 4}).Where(func(int) bool {
+		pulled++
+		return true
+	}).CountBy(func(item int) int { return item % 2 })
+
+	q.Iterate(func(KeyValue[int, int]) bool { return false })
+	if pulled != 4 {
+		t.Errorf("CountBy pulled %d elements expected 4", pulled)
+	}
+}
+
+func TestAggregateByConsumesSourceBeforeYielding(t *testing.T) {
+	pulled := 0
+	q := FromSlice([]int{1, 2, 3, 4}).Where(func(int) bool {
+		pulled++
+		return true
+	}).AggregateBy(
+		func(item int) int { return item % 2 },
+		0,
+		func(total, item int) int { return total + item },
+	)
+
+	q.Iterate(func(KeyValue[int, int]) bool { return false })
+	if pulled != 4 {
+		t.Errorf("AggregateBy pulled %d elements expected 4", pulled)
 	}
 }

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -114,3 +114,47 @@ func BenchmarkAggregateBy(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkJoin(b *testing.B) {
+	const keys = 1024
+	source := make([]int, 65536)
+	for i := range source {
+		source[i] = i % keys
+	}
+	outer, inner := FromSlice(source), Range(0, keys)
+	identity := func(i int) int { return i }
+	pair := func(a, b int) int { return a + b }
+
+	b.Run("Join", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			if got := outer.Join(inner, identity, identity, pair).Count(); got != len(source) {
+				b.Fatalf("Join count=%d expected %d", got, len(source))
+			}
+		}
+	})
+	b.Run("LeftJoin", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			if got := outer.LeftJoin(inner, identity, identity, pair).Count(); got != len(source) {
+				b.Fatalf("LeftJoin count=%d expected %d", got, len(source))
+			}
+		}
+	})
+	b.Run("RightJoin", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			if got := inner.RightJoin(outer, identity, identity, pair).Count(); got != len(source) {
+				b.Fatalf("RightJoin count=%d expected %d", got, len(source))
+			}
+		}
+	})
+}
+
+func BenchmarkSequence(b *testing.B) {
+	const count = 65536
+	q := Sequence(0, count-1, 1)
+
+	for n := 0; n < b.N; n++ {
+		if got := Sum(q); got != count*(count-1)/2 {
+			b.Fatalf("Sequence sum=%d expected %d", got, count*(count-1)/2)
+		}
+	}
+}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -71,3 +71,46 @@ func BenchmarkChunk(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkCountBy(b *testing.B) {
+	const keys = 1024
+	source := make([]int, 65536)
+	for i := range source {
+		source[i] = i % keys
+	}
+	q := FromSlice(source)
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		if got := q.CountBy(func(i int) int { return i }).Count(); got != keys {
+			b.Fatalf("CountBy count=%d expected %d", got, keys)
+		}
+	}
+}
+
+func BenchmarkAggregateBy(b *testing.B) {
+	const keys = 1024
+	source := make([]int, 65536)
+	for i := range source {
+		source[i] = i % keys
+	}
+	q := FromSlice(source)
+	keySelector := func(i int) int { return i }
+	seedSelector := func(int) int { return 0 }
+	accumulate := func(total, item int) int { return total + item }
+
+	b.Run("Seed", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			if got := q.AggregateBy(keySelector, 0, accumulate).Count(); got != keys {
+				b.Fatalf("AggregateBy count=%d expected %d", got, keys)
+			}
+		}
+	})
+	b.Run("SeedSelector", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			if got := q.AggregateByWithSeedSelector(keySelector, seedSelector, accumulate).Count(); got != keys {
+				b.Fatalf("AggregateByWithSeedSelector count=%d expected %d", got, keys)
+			}
+		}
+	})
+}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -146,6 +146,13 @@ func BenchmarkJoin(b *testing.B) {
 			}
 		}
 	})
+	b.Run("FullJoin", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			if got := outer.FullJoin(inner, identity, identity, pair).Count(); got != len(source) {
+				b.Fatalf("FullJoin count=%d expected %d", got, len(source))
+			}
+		}
+	})
 }
 
 func BenchmarkSequence(b *testing.B) {

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -59,3 +59,15 @@ func BenchmarkZipSkipTake(b *testing.B) {
 		}).Skip(2).Take(5).Count()
 	}
 }
+
+func BenchmarkChunk(b *testing.B) {
+	const chunkSize = 256
+	source := make([]int, 65536)
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		if got := Chunk(FromSlice(source), chunkSize).Count(); got != len(source)/chunkSize {
+			b.Fatalf("Chunk count=%d expected %d", got, len(source)/chunkSize)
+		}
+	}
+}

--- a/chunk.go
+++ b/chunk.go
@@ -1,41 +1,81 @@
 package linq
 
-import "slices"
+import (
+	"iter"
+	"slices"
+)
 
 // Chunk splits the elements of a collection into slices of at most size
 // elements. Every returned slice has its own backing storage. Chunk panics if
 // size is less than one.
+//
+// Chunk is a package-level function because a Query[T].Chunk() Query[[]T]
+// method would be a recursive instantiation. To split a collection without
+// leaving a chain, use the ChunkBy method.
 func Chunk[T any](q Query[T], size int) Query[[]T] {
 	if size < 1 {
 		panic("linq: chunk size must be positive")
 	}
 
-	resultSize := 0
-	if q.size > 0 {
-		resultSize = (q.size-1)/size + 1
-	}
-
 	return Query[[]T]{
-		Iterate: func(yield func([]T) bool) {
-			var chunk []T
-			q.Iterate(func(item T) bool {
-				if chunk == nil {
-					chunk = make([]T, 0, size)
-				}
-				chunk = append(chunk, item)
-				if len(chunk) < size {
-					return true
-				}
-
-				current := chunk
-				chunk = nil
-				return yield(current)
-			})
-
-			if len(chunk) > 0 {
-				yield(slices.Clip(chunk))
-			}
-		},
-		size: resultSize,
+		Iterate: chunked(q, size),
+		size:    chunkCount(q.size, size),
 	}
+}
+
+// ChunkBy splits the elements of a collection into slices of at most size
+// elements and projects each slice with selector. It is Chunk followed by
+// Select, available as a method so that it composes inside a chain. ChunkBy
+// panics if size is less than one.
+//
+// Each slice passed to selector has its own backing storage and is not reused
+// afterwards, so selector may retain it.
+//
+// ChunkBy is a generic method: the result type TResult is inferred from the
+// selector function.
+func (q Query[T]) ChunkBy[TResult any](size int, selector func([]T) TResult) Query[TResult] {
+	if size < 1 {
+		panic("linq: chunk size must be positive")
+	}
+
+	return Query[TResult]{
+		Iterate: func(yield func(TResult) bool) {
+			chunked(q, size)(func(chunk []T) bool {
+				return yield(selector(chunk))
+			})
+		},
+		size: chunkCount(q.size, size),
+	}
+}
+
+// chunked yields independent chunks without constructing Query[[]T], which
+// would cause a recursive instantiation inside ChunkBy.
+func chunked[T any](q Query[T], size int) iter.Seq[[]T] {
+	return func(yield func([]T) bool) {
+		var chunk []T
+		q.Iterate(func(item T) bool {
+			if chunk == nil {
+				chunk = make([]T, 0, size)
+			}
+			chunk = append(chunk, item)
+			if len(chunk) < size {
+				return true
+			}
+
+			current := chunk
+			chunk = nil
+			return yield(current)
+		})
+
+		if len(chunk) > 0 {
+			yield(slices.Clip(chunk))
+		}
+	}
+}
+
+func chunkCount(length, size int) int {
+	if length <= 0 {
+		return 0
+	}
+	return (length-1)/size + 1
 }

--- a/chunk.go
+++ b/chunk.go
@@ -1,0 +1,41 @@
+package linq
+
+import "slices"
+
+// Chunk splits the elements of a collection into slices of at most size
+// elements. Every returned slice has its own backing storage. Chunk panics if
+// size is less than one.
+func Chunk[T any](q Query[T], size int) Query[[]T] {
+	if size < 1 {
+		panic("linq: chunk size must be positive")
+	}
+
+	resultSize := 0
+	if q.size > 0 {
+		resultSize = (q.size-1)/size + 1
+	}
+
+	return Query[[]T]{
+		Iterate: func(yield func([]T) bool) {
+			var chunk []T
+			q.Iterate(func(item T) bool {
+				if chunk == nil {
+					chunk = make([]T, 0, size)
+				}
+				chunk = append(chunk, item)
+				if len(chunk) < size {
+					return true
+				}
+
+				current := chunk
+				chunk = nil
+				return yield(current)
+			})
+
+			if len(chunk) > 0 {
+				yield(slices.Clip(chunk))
+			}
+		},
+		size: resultSize,
+	}
+}

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -1,0 +1,69 @@
+package linq
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestChunk(t *testing.T) {
+	tests := []struct {
+		input []int
+		size  int
+		want  [][]int
+	}{
+		{nil, 3, nil},
+		{[]int{1, 2, 3}, 1, [][]int{{1}, {2}, {3}}},
+		{[]int{1, 2, 3, 4, 5, 6}, 3, [][]int{{1, 2, 3}, {4, 5, 6}}},
+		{[]int{1, 2, 3, 4, 5, 6, 7}, 3, [][]int{{1, 2, 3}, {4, 5, 6}, {7}}},
+	}
+
+	for _, test := range tests {
+		if q := Chunk(FromSlice(test.input), test.size); !testQueryIteration(q, test.want) {
+			t.Errorf("Chunk(%v, %d)=%v expected %v", test.input, test.size, toSlice(q), test.want)
+		}
+	}
+}
+
+func TestChunkClipsAndSeparatesSlices(t *testing.T) {
+	chunks := Chunk(FromSlice([]int{1, 2, 3, 4, 5}), 3).ToSlice()
+	for _, chunk := range chunks {
+		if cap(chunk) != len(chunk) {
+			t.Errorf("chunk %v has cap=%d expected %d", chunk, cap(chunk), len(chunk))
+		}
+	}
+
+	chunks[0][0] = 99
+	if !slices.Equal(chunks[1], []int{4, 5}) {
+		t.Errorf("mutating one chunk changed another: %v", chunks)
+	}
+}
+
+func TestChunkInvalidSizePanics(t *testing.T) {
+	for _, size := range []int{0, -1} {
+		mustPanic(t, func() { Chunk(FromSlice([]int{1}), size) })
+	}
+}
+
+func TestChunkStopsPullingAfterConsumerStops(t *testing.T) {
+	pulled := 0
+	q := Chunk(FromSlice([]int{1, 2, 3, 4, 5}).Where(func(int) bool {
+		pulled++
+		return true
+	}), 3)
+
+	var got [][]int
+	q.Iterate(func(chunk []int) bool {
+		got = append(got, chunk)
+		return false
+	})
+
+	if len(got) != 1 {
+		t.Fatalf("Chunk early exit yielded %v expected one chunk", got)
+	}
+	if !slices.Equal(got[0], []int{1, 2, 3}) {
+		t.Errorf("first chunk=%v expected [1 2 3]", got[0])
+	}
+	if pulled != 3 {
+		t.Errorf("source pulled %d elements expected 3", pulled)
+	}
+}

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -67,3 +67,70 @@ func TestChunkStopsPullingAfterConsumerStops(t *testing.T) {
 		t.Errorf("source pulled %d elements expected 3", pulled)
 	}
 }
+
+func TestChunkBy(t *testing.T) {
+	tests := []struct {
+		input []int
+		size  int
+		want  []int
+	}{
+		{nil, 3, nil},
+		{[]int{1, 2, 3}, 1, []int{1, 2, 3}},
+		{[]int{1, 2, 3, 4, 5, 6}, 3, []int{6, 15}},
+		{[]int{1, 2, 3, 4, 5, 6, 7}, 3, []int{6, 15, 7}},
+	}
+
+	sum := func(chunk []int) int {
+		total := 0
+		for _, v := range chunk {
+			total += v
+		}
+		return total
+	}
+
+	for _, test := range tests {
+		q := FromSlice(test.input).ChunkBy(test.size, sum)
+		if !testQueryIteration(q, test.want) {
+			t.Errorf("ChunkBy(%v, %d)=%v expected %v", test.input, test.size, toSlice(q), test.want)
+		}
+	}
+}
+
+func TestChunkByChainsAndChangesType(t *testing.T) {
+	got := FromSlice([]int{1, 2, 3, 4, 5}).
+		ChunkBy(2, func(chunk []int) int { return len(chunk) }).
+		Where(func(n int) bool { return n == 2 }).
+		ToSlice()
+
+	if want := []int{2, 2}; !slices.Equal(got, want) {
+		t.Errorf("ChunkBy().Where()=%v expected %v", got, want)
+	}
+}
+
+func TestChunkByInvalidSizePanics(t *testing.T) {
+	identity := func(chunk []int) []int { return chunk }
+	for _, size := range []int{0, -1} {
+		mustPanic(t, func() { FromSlice([]int{1}).ChunkBy(size, identity) })
+	}
+}
+
+func TestChunkByStopsPullingAfterConsumerStops(t *testing.T) {
+	pulled := 0
+	q := FromSlice([]int{1, 2, 3, 4, 5}).Where(func(int) bool {
+		pulled++
+		return true
+	}).ChunkBy(3, func(chunk []int) int { return len(chunk) })
+
+	var got []int
+	q.Iterate(func(n int) bool {
+		got = append(got, n)
+		return false
+	})
+
+	if len(got) != 1 {
+		t.Fatalf("got %v expected one chunk", got)
+	}
+	if pulled != 3 {
+		t.Errorf("source pulled %d elements expected 3", pulled)
+	}
+}

--- a/example_test.go
+++ b/example_test.go
@@ -94,6 +94,20 @@ func ExampleRange() {
 	// [1 2 3 4 5]
 }
 
+func ExampleSequence() {
+	fmt.Println(Sequence(2, 10, 3).ToSlice())
+
+	// Output:
+	// [2 5 8]
+}
+
+func ExampleInfiniteSequence() {
+	fmt.Println(InfiniteSequence(10, -2).Take(4).ToSlice())
+
+	// Output:
+	// [10 8 6 4]
+}
+
 func ExampleRepeat() {
 	fmt.Println(Repeat("go", 3).ToSlice())
 
@@ -239,6 +253,44 @@ func ExampleQuery_Join() {
 	// Terry - Barley
 	// Terry - Boots
 	// Charlotte - Whiskers
+}
+
+func ExampleQuery_LeftJoin() {
+	query := FromSlice([]string{"apple", "banana"}).LeftJoin(
+		FromSlice([]string{"apricot"}),
+		func(s string) byte { return s[0] },
+		func(s string) byte { return s[0] },
+		func(left, right string) string {
+			if right == "" {
+				right = "<none>"
+			}
+			return left + " - " + right
+		},
+	)
+
+	fmt.Println(query.ToSlice())
+
+	// Output:
+	// [apple - apricot banana - <none>]
+}
+
+func ExampleQuery_RightJoin() {
+	query := FromSlice([]string{"apple"}).RightJoin(
+		FromSlice([]string{"apricot", "banana"}),
+		func(s string) byte { return s[0] },
+		func(s string) byte { return s[0] },
+		func(left, right string) string {
+			if left == "" {
+				left = "<none>"
+			}
+			return left + " - " + right
+		},
+	)
+
+	fmt.Println(query.ToSlice())
+
+	// Output:
+	// [apple - apricot <none> - banana]
 }
 
 func ExampleQuery_GroupJoin() {

--- a/example_test.go
+++ b/example_test.go
@@ -293,6 +293,28 @@ func ExampleQuery_RightJoin() {
 	// [apple - apricot <none> - banana]
 }
 
+func ExampleQuery_FullJoin() {
+	query := FromSlice([]string{"apple", "banana"}).FullJoin(
+		FromSlice([]string{"apricot", "cherry"}),
+		func(s string) byte { return s[0] },
+		func(s string) byte { return s[0] },
+		func(left, right string) string {
+			if left == "" {
+				left = "<none>"
+			}
+			if right == "" {
+				right = "<none>"
+			}
+			return left + " - " + right
+		},
+	)
+
+	fmt.Println(query.ToSlice())
+
+	// Output:
+	// [apple - apricot banana - <none> <none> - cherry]
+}
+
 func ExampleQuery_GroupJoin() {
 	fruits := []string{"apple", "banana", "apricot", "cherry", "clementine"}
 

--- a/example_test.go
+++ b/example_test.go
@@ -615,7 +615,7 @@ func ExampleQuery_Take() {
 }
 
 func ExampleQuery_TakeRange() {
-	fmt.Println(Range(0, 10).TakeRange(PositionFromEnd(4), PositionFromEnd(1)).ToSlice())
+	fmt.Println(Range(0, 10).TakeRange(FromEnd(4), FromEnd(1)).ToSlice())
 
 	// Output:
 	// [6 7 8]
@@ -689,7 +689,7 @@ func ExampleQuery_IndexOf() {
 }
 
 func ExampleQuery_ElementAt() {
-	value, ok := FromSlice([]string{"a", "b", "c"}).ElementAt(PositionFromEnd(1))
+	value, ok := FromSlice([]string{"a", "b", "c"}).ElementAt(FromEnd(1))
 	fmt.Println(value, ok)
 
 	// Output:

--- a/example_test.go
+++ b/example_test.go
@@ -378,6 +378,21 @@ func ExampleQuery_Zip() {
 	// [1=one 2=two 3=three]
 }
 
+func ExampleQuery_Zip3() {
+	query := Range(1, 3).Zip3(
+		FromSlice([]string{"one", "two", "three"}),
+		FromSlice([]string{"I", "II", "III"}),
+		func(n int, word, roman string) string {
+			return fmt.Sprintf("%d=%s=%s", n, word, roman)
+		},
+	)
+
+	fmt.Println(query.ToSlice())
+
+	// Output:
+	// [1=one=I 2=two=II 3=three=III]
+}
+
 func ExampleQuery_Aggregate() {
 	fruits := []string{"apple", "mango", "orange", "passionfruit", "grape"}
 
@@ -481,6 +496,13 @@ func ExampleQuery_Take() {
 	// [1 2 3]
 }
 
+func ExampleQuery_TakeRange() {
+	fmt.Println(Range(0, 10).TakeRange(IndexFromEnd(4), IndexFromEnd(1)).ToSlice())
+
+	// Output:
+	// [6 7 8]
+}
+
 func ExampleQuery_TakeWhile() {
 	fruits := []string{"apple", "banana", "mango", "orange", "passionfruit", "grape"}
 
@@ -546,6 +568,21 @@ func ExampleQuery_IndexOf() {
 
 	// Output:
 	// 1
+}
+
+func ExampleQuery_ElementAt() {
+	value, ok := FromSlice([]string{"a", "b", "c"}).ElementAt(IndexFromEnd(1))
+	fmt.Println(value, ok)
+
+	// Output:
+	// c true
+}
+
+func ExampleChunk() {
+	fmt.Println(Chunk(Range(1, 5), 2).ToSlice())
+
+	// Output:
+	// [[1 2] [3 4] [5]]
 }
 
 func ExampleQuery_ToMapBy() {

--- a/example_test.go
+++ b/example_test.go
@@ -423,6 +423,42 @@ func ExampleQuery_AggregateWithSeed() {
 	// 16
 }
 
+func ExampleQuery_AggregateBy() {
+	type score struct {
+		id    string
+		value int
+	}
+	scores := []score{{"0", 42}, {"1", 5}, {"1", 10}, {"0", 25}}
+
+	totals := FromSlice(scores).AggregateBy(
+		func(score score) string { return score.id },
+		0,
+		func(total int, score score) int { return total + score.value },
+	)
+	fmt.Println(totals.ToSlice())
+
+	// Output:
+	// [{0 67} {1 15}]
+}
+
+func ExampleQuery_AggregateByWithSeedSelector() {
+	type sale struct {
+		region string
+		amount int
+	}
+	sales := []sale{{"EU", 1}, {"APAC", 5}, {"EU", 2}}
+
+	totals := FromSlice(sales).AggregateByWithSeedSelector(
+		func(sale sale) string { return sale.region },
+		func(region string) int { return len(region) },
+		func(total int, sale sale) int { return total + sale.amount },
+	)
+	fmt.Println(totals.ToSlice())
+
+	// Output:
+	// [{EU 5} {APAC 9}]
+}
+
 func ExampleQuery_All() {
 	pets := map[string]int{"Barley": 10}
 
@@ -452,6 +488,14 @@ func ExampleQuery_CountWith() {
 
 	// Output:
 	// 5
+}
+
+func ExampleQuery_CountBy() {
+	counts := FromString("abracadabra").CountBy(func(r rune) string { return string(r) })
+	fmt.Println(counts.ToSlice())
+
+	// Output:
+	// [{a 5} {b 2} {r 2} {c 1} {d 1}]
 }
 
 func ExampleQuery_First() {
@@ -497,7 +541,7 @@ func ExampleQuery_Take() {
 }
 
 func ExampleQuery_TakeRange() {
-	fmt.Println(Range(0, 10).TakeRange(IndexFromEnd(4), IndexFromEnd(1)).ToSlice())
+	fmt.Println(Range(0, 10).TakeRange(PositionFromEnd(4), PositionFromEnd(1)).ToSlice())
 
 	// Output:
 	// [6 7 8]
@@ -571,11 +615,18 @@ func ExampleQuery_IndexOf() {
 }
 
 func ExampleQuery_ElementAt() {
-	value, ok := FromSlice([]string{"a", "b", "c"}).ElementAt(IndexFromEnd(1))
+	value, ok := FromSlice([]string{"a", "b", "c"}).ElementAt(PositionFromEnd(1))
 	fmt.Println(value, ok)
 
 	// Output:
 	// c true
+}
+
+func ExampleIndex() {
+	fmt.Println(Index(FromSlice([]string{"zero", "one"})).ToSlice())
+
+	// Output:
+	// [{0 zero} {1 one}]
 }
 
 func ExampleChunk() {

--- a/from.go
+++ b/from.go
@@ -48,8 +48,8 @@ func (q Query[T]) collect() []T {
 	return slices.Collect(q.Iterate)
 }
 
-// KeyValue is a type used to iterate over a map. This type is also used by
-// the ToMap function to output the result of a query into a map.
+// KeyValue pairs a key with a value. Map queries and keyed operators yield
+// KeyValue elements, which ToMap can collect into a map.
 type KeyValue[TKey comparable, TValue any] struct {
 	Key   TKey
 	Value TValue

--- a/from.go
+++ b/from.go
@@ -14,16 +14,19 @@ type Query[T any] struct {
 
 	// size hints the exact number of elements the query yields, when that is
 	// cheaply known; zero means unknown. Sources with a known length set it,
-	// and only operators that emit exactly one element per source element may
-	// propagate it. Operators that change cardinality need to do nothing:
-	// they construct a fresh Query without the field, and the hint safely
-	// zeroes out.
+	// and operators may propagate a size that can be derived exactly from their
+	// inputs. Operators whose cardinality is unknown construct a fresh Query
+	// without the field, and the hint safely zeroes out.
 	//
 	// The hint is consumed only as the capacity of preallocated result
 	// slices, so it can never change what a query produces. A missing hint
 	// forfeits the preallocation; a stale one (e.g., a source map mutated
 	// after the query was built) merely mis-sizes it.
 	size int
+}
+
+func emptyQuery[T any]() Query[T] {
+	return Query[T]{Iterate: func(func(T) bool) {}}
 }
 
 // collect gathers all elements into a slice, preallocating when the query

--- a/from.go
+++ b/from.go
@@ -3,6 +3,7 @@ package linq
 import (
 	"context"
 	"iter"
+	"math"
 	"slices"
 )
 
@@ -156,6 +157,99 @@ func Range(start, count int) Query[int] {
 			}
 		},
 		size: max(count, 0),
+	}
+}
+
+// Sequence generates a numeric sequence from start towards endInclusive by
+// repeatedly adding step. It panics if any argument is NaN, if step is zero
+// while the bounds differ, or if step points away from endInclusive.
+//
+// endInclusive is yielded only when the sum lands on it exactly, so
+// Sequence(0, 5, 2) stops at 4. A step that would overflow T instead of
+// reaching the bound also ends the sequence: Sequence(int8(126), 127, 2)
+// yields 126 alone.
+func Sequence[T Number](start, endInclusive, step T) Query[T] {
+	if start != start {
+		panic("linq: sequence start must not be NaN")
+	}
+	if endInclusive != endInclusive {
+		panic("linq: sequence end must not be NaN")
+	}
+	if step != step {
+		panic("linq: sequence step must not be NaN")
+	}
+
+	if start == endInclusive {
+		return Repeat(start, 1)
+	}
+	if step == 0 {
+		panic("linq: sequence step must not be zero unless the bounds are equal")
+	}
+
+	increasing := step > 0
+	if increasing != (endInclusive > start) {
+		panic("linq: sequence step points away from end")
+	}
+
+	return Query[T]{
+		Iterate: func(yield func(T) bool) {
+			for current := start; yield(current); {
+				next := current + step
+				// Stop once next passes the bound, or once overflow wrapped it
+				// back the way it came.
+				if increasing {
+					if next > endInclusive || next <= current {
+						return
+					}
+				} else if next < endInclusive || next >= current {
+					return
+				}
+
+				current = next
+			}
+		},
+		size: sequenceSize(start, endInclusive, step),
+	}
+}
+
+// sequenceSize returns the exact number of elements Sequence yields, or zero
+// when that count is not cheaply derivable: a floating point step accumulates
+// rounding, and a count wider than an int cannot be a capacity anyway.
+//
+// The span is measured in uint64 rather than in T so that it survives bounds a
+// signed T cannot hold (int8 spans -128..127 as 255), and so that negating the
+// most negative step stays correct.
+//
+// It expects what Sequence has already validated: a nonzero step pointing from
+// start towards endInclusive. A zero step would divide by zero below.
+func sequenceSize[T Number](start, endInclusive, step T) int {
+	// Integer division truncates to zero; only a floating point T keeps a half.
+	if half := T(1) / 2; half != 0 {
+		return 0
+	}
+
+	var span, magnitude uint64
+	if step > 0 {
+		span, magnitude = uint64(endInclusive)-uint64(start), uint64(step)
+	} else {
+		span, magnitude = uint64(start)-uint64(endInclusive), -uint64(step)
+	}
+
+	steps := span / magnitude
+	if steps >= uint64(math.MaxInt) {
+		return 0
+	}
+	return int(steps) + 1
+}
+
+// InfiniteSequence generates an unbounded numeric sequence by repeatedly
+// adding step to start. Iteration ends only when the consumer stops it.
+func InfiniteSequence[T Number](start, step T) Query[T] {
+	return Query[T]{
+		Iterate: func(yield func(T) bool) {
+			for current := start; yield(current); current += step {
+			}
+		},
 	}
 }
 

--- a/from.go
+++ b/from.go
@@ -26,7 +26,8 @@ type Query[T any] struct {
 	size int
 }
 
-func emptyQuery[T any]() Query[T] {
+// Empty returns an empty query of the specified element type.
+func Empty[T any]() Query[T] {
 	return Query[T]{Iterate: func(func(T) bool) {}}
 }
 

--- a/from_test.go
+++ b/from_test.go
@@ -106,6 +106,19 @@ func TestFromSeq(t *testing.T) {
 	}
 }
 
+func TestEmptyQuery(t *testing.T) {
+	q := Empty[int]()
+	if !testQueryIteration(q, nil) {
+		t.Error("Empty[int]() yielded elements")
+	}
+	if q.Any() || q.Count() != 0 {
+		t.Error("Empty[int]() is not empty")
+	}
+	if appended := q.Append(1); !testQueryIteration(appended, []int{1}) {
+		t.Errorf("Empty[int]().Append(1)=%v expected [1]", appended.ToSlice())
+	}
+}
+
 func TestRange(t *testing.T) {
 	w := []int{-2, -1, 0, 1, 2}
 

--- a/from_test.go
+++ b/from_test.go
@@ -2,6 +2,7 @@ package linq
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 )
@@ -110,6 +111,89 @@ func TestRange(t *testing.T) {
 
 	if q := Range(-2, 5); !testQueryIteration(q, w) {
 		t.Errorf("Range(-2, 5)=%v expected %v", toSlice(q), w)
+	}
+}
+
+func TestSequence(t *testing.T) {
+	tests := []struct {
+		name             string
+		start, end, step int
+		want             []int
+	}{
+		{"increasing", 1, 5, 1, []int{1, 2, 3, 4, 5}},
+		{"decreasing", 5, 1, -2, []int{5, 3, 1}},
+		{"bound not reached", 0, 5, 2, []int{0, 2, 4}},
+		{"equal positive", 3, 3, 1, []int{3}},
+		{"equal negative", 3, 3, -1, []int{3}},
+		{"equal zero", 3, 3, 0, []int{3}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			q := Sequence(test.start, test.end, test.step)
+			if !testQueryIteration(q, test.want) {
+				t.Errorf("Sequence(%v, %v, %v)=%v expected %v",
+					test.start, test.end, test.step, q.ToSlice(), test.want)
+			}
+		})
+	}
+}
+
+func TestSequenceNumericTypes(t *testing.T) {
+	type score int16
+
+	if q := Sequence(score(-2), score(4), score(3)); !testQueryIteration(q, []score{-2, 1, 4}) {
+		t.Errorf("Sequence(named type)=%v expected [-2 1 4]", q.ToSlice())
+	}
+	if q := Sequence(0.5, 1.25, 0.25); !testQueryIteration(q, []float64{0.5, 0.75, 1, 1.25}) {
+		t.Errorf("Sequence(float64)=%v expected [0.5 0.75 1 1.25]", q.ToSlice())
+	}
+	if q := Sequence(uint8(254), uint8(255), uint8(2)); !testQueryIteration(q, []uint8{254}) {
+		t.Errorf("Sequence(uint8 overflow)=%v expected [254]", q.ToSlice())
+	}
+	if q := Sequence(int8(126), int8(127), int8(2)); !testQueryIteration(q, []int8{126}) {
+		t.Errorf("Sequence(int8 overflow)=%v expected [126]", q.ToSlice())
+	}
+}
+
+func TestSequenceInvalidArgumentsPanic(t *testing.T) {
+	for _, f := range []func(){
+		func() { Sequence(0, 1, 0) },
+		func() { Sequence(1, 0, 1) },
+		func() { Sequence(0, 1, -1) },
+		func() { Sequence(math.NaN(), 1, 1) },
+		func() { Sequence(0, math.NaN(), 1) },
+		func() { Sequence(0, 1, math.NaN()) },
+	} {
+		mustPanic(t, f)
+	}
+}
+
+func TestInfiniteSequence(t *testing.T) {
+	tests := []struct {
+		name        string
+		start, step int
+		count       int
+		want        []int
+	}{
+		{"increasing", 1, 2, 5, []int{1, 3, 5, 7, 9}},
+		{"decreasing", 5, -2, 4, []int{5, 3, 1, -1}},
+		{"constant", 7, 0, 3, []int{7, 7, 7}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			q := InfiniteSequence(test.start, test.step).Take(test.count)
+			if !testQueryIteration(q, test.want) {
+				t.Errorf("InfiniteSequence(%v, %v).Take(%v)=%v expected %v",
+					test.start, test.step, test.count, q.ToSlice(), test.want)
+			}
+		})
+	}
+
+	q := InfiniteSequence(uint8(254), uint8(2)).Take(3)
+	if !testQueryIteration(q, []uint8{254, 0, 2}) {
+		t.Errorf("InfiniteSequence(uint8 overflow)=%v expected [254 0 2]", q.ToSlice())
 	}
 }
 

--- a/groupjoin.go
+++ b/groupjoin.go
@@ -1,5 +1,7 @@
 package linq
 
+import "reflect"
+
 // GroupJoin correlates the elements of two collections based on key equality
 // and groups the results.
 //
@@ -31,11 +33,11 @@ func (q Query[T]) GroupJoin[TInner any, TKey comparable, TResult any](inner Quer
 	return Query[TResult]{
 		Iterate: func(yield func(TResult) bool) {
 			innerLookup := buildJoinLookup(inner, innerKeySelector)
+			interfaceKey := reflect.TypeFor[TKey]().Kind() == reflect.Interface
 
 			q.Iterate(func(outerItem T) bool {
-				outerKey := outerKeySelector(outerItem)
-				innerGroup, ok := innerLookup[outerKey]
-				if !ok {
+				innerGroup := joinGroupFor(innerLookup, outerKeySelector(outerItem), interfaceKey)
+				if innerGroup == nil {
 					innerGroup = []TInner{}
 				}
 

--- a/groupjoin.go
+++ b/groupjoin.go
@@ -20,6 +20,9 @@ package linq
 //
 // GroupJoin preserves the order of the elements of outer, and for each element
 // of outer, the order of the matching elements from inner.
+//
+// Elements whose key is nil take no part in the join: like .NET LINQ, GroupJoin
+// never matches a nil key, not even against another nil key.
 func (q Query[T]) GroupJoin[TInner any, TKey comparable, TResult any](inner Query[TInner],
 	outerKeySelector func(T) TKey,
 	innerKeySelector func(TInner) TKey,
@@ -27,12 +30,7 @@ func (q Query[T]) GroupJoin[TInner any, TKey comparable, TResult any](inner Quer
 
 	return Query[TResult]{
 		Iterate: func(yield func(TResult) bool) {
-			innerLookup := make(map[TKey][]TInner)
-			inner.Iterate(func(innerItem TInner) bool {
-				innerKey := innerKeySelector(innerItem)
-				innerLookup[innerKey] = append(innerLookup[innerKey], innerItem)
-				return true
-			})
+			innerLookup := buildJoinLookup(inner, innerKeySelector)
 
 			q.Iterate(func(outerItem T) bool {
 				outerKey := outerKeySelector(outerItem)

--- a/index.go
+++ b/index.go
@@ -1,46 +1,47 @@
 package linq
 
-// Index represents a position counted from the start or end of a sequence.
-// Its zero value is IndexFromStart(0).
-type Index struct {
+// Position represents a position counted from the start or end of a sequence.
+// Its zero value is PositionFromStart(0).
+// PositionFromEnd(0) points just past the sequence and does not identify an element.
+type Position struct {
 	value   int
 	fromEnd bool
 }
 
-// NewIndex returns an Index counted from the end of a sequence when fromEnd is
+// NewPosition returns a Position counted from the end of a sequence when fromEnd is
 // true, or from the start otherwise. It panics if value is negative.
-func NewIndex(value int, fromEnd bool) Index {
+func NewPosition(value int, fromEnd bool) Position {
 	if value < 0 {
-		panic("linq: index must be non-negative")
+		panic("linq: position must be non-negative")
 	}
-	return Index{value: value, fromEnd: fromEnd}
+	return Position{value: value, fromEnd: fromEnd}
 }
 
-// IndexFromStart returns an Index counted from the start of a sequence. It
+// PositionFromStart returns a Position counted from the start of a sequence. It
 // panics if value is negative.
-func IndexFromStart(value int) Index {
-	return NewIndex(value, false)
+func PositionFromStart(value int) Position {
+	return NewPosition(value, false)
 }
 
-// IndexFromEnd returns an Index counted from the end of a sequence.
-// IndexFromEnd(1) identifies the last element; IndexFromEnd(0) identifies the
+// PositionFromEnd returns a Position counted from the end of a sequence.
+// PositionFromEnd(1) identifies the last element; PositionFromEnd(0) identifies the
 // position immediately after it. It panics if value is negative.
-func IndexFromEnd(value int) Index {
-	return NewIndex(value, true)
+func PositionFromEnd(value int) Position {
+	return NewPosition(value, true)
 }
 
-func (i Index) offset(length int) int {
-	if i.fromEnd {
-		return max(length-i.value, 0)
+func (p Position) offset(length int) int {
+	if p.fromEnd {
+		return max(length-p.value, 0)
 	}
-	return min(i.value, length)
+	return min(p.value, length)
 }
 
-// ElementAt returns the element at index and a boolean reporting whether that
+// ElementAt returns the element at position and a boolean reporting whether that
 // position exists.
-func (q Query[T]) ElementAt(index Index) (T, bool) {
-	value := index.value
-	if index.fromEnd {
+func (q Query[T]) ElementAt(position Position) (T, bool) {
+	value := position.value
+	if position.fromEnd {
 		var zero T
 		if value == 0 {
 			return zero, false
@@ -55,17 +56,24 @@ func (q Query[T]) ElementAt(index Index) (T, bool) {
 
 	var result T
 	found := false
-	position := 0
+	current := 0
 	q.Iterate(func(item T) bool {
-		if position == value {
+		if current == value {
 			result = item
 			found = true
 			return false
 		}
-		position++
+		current++
 		return true
 	})
 	return result, found
+}
+
+// Index pairs each item with its zero-based index as a KeyValue.
+func Index[T any](q Query[T]) Query[KeyValue[int, T]] {
+	return q.SelectIndexed(func(index int, item T) KeyValue[int, T] {
+		return KeyValue[int, T]{Key: index, Value: item}
+	})
 }
 
 // IndexOf searches for an element that matches the conditions defined by a specified predicate

--- a/index.go
+++ b/index.go
@@ -1,5 +1,73 @@
 package linq
 
+// Index represents a position counted from the start or end of a sequence.
+// Its zero value is IndexFromStart(0).
+type Index struct {
+	value   int
+	fromEnd bool
+}
+
+// NewIndex returns an Index counted from the end of a sequence when fromEnd is
+// true, or from the start otherwise. It panics if value is negative.
+func NewIndex(value int, fromEnd bool) Index {
+	if value < 0 {
+		panic("linq: index must be non-negative")
+	}
+	return Index{value: value, fromEnd: fromEnd}
+}
+
+// IndexFromStart returns an Index counted from the start of a sequence. It
+// panics if value is negative.
+func IndexFromStart(value int) Index {
+	return NewIndex(value, false)
+}
+
+// IndexFromEnd returns an Index counted from the end of a sequence.
+// IndexFromEnd(1) identifies the last element; IndexFromEnd(0) identifies the
+// position immediately after it. It panics if value is negative.
+func IndexFromEnd(value int) Index {
+	return NewIndex(value, true)
+}
+
+func (i Index) offset(length int) int {
+	if i.fromEnd {
+		return max(length-i.value, 0)
+	}
+	return min(i.value, length)
+}
+
+// ElementAt returns the element at index and a boolean reporting whether that
+// position exists.
+func (q Query[T]) ElementAt(index Index) (T, bool) {
+	value := index.value
+	if index.fromEnd {
+		var zero T
+		if value == 0 {
+			return zero, false
+		}
+
+		items, _ := lastItems(q, value)
+		if len(items) < value {
+			return zero, false
+		}
+		return items[0], true
+	}
+
+	var result T
+	found := false
+	position := 0
+	q.Iterate(func(item T) bool {
+		if position == value {
+			result = item
+			found = true
+			return false
+		}
+		position++
+		return true
+	})
+	return result, found
+}
+
 // IndexOf searches for an element that matches the conditions defined by a specified predicate
 // and returns the zero-based index of the first occurrence within the collection. This method
 // returns -1 if an item that matches the conditions is not found.

--- a/index.go
+++ b/index.go
@@ -1,15 +1,16 @@
 package linq
 
 // Position represents a position counted from the start or end of a sequence.
-// Its zero value is PositionFromStart(0).
-// PositionFromEnd(0) points just past the sequence and does not identify an element.
+// Its zero value is FromStart(0).
+// FromEnd(0) points just past the sequence and does not identify an element.
 type Position struct {
 	value   int
 	fromEnd bool
 }
 
-// NewPosition returns a Position counted from the end of a sequence when fromEnd is
-// true, or from the start otherwise. It panics if value is negative.
+// NewPosition returns a Position counted from the end of a sequence when
+// fromEnd is true, or from the start otherwise. It panics if value is
+// negative.
 func NewPosition(value int, fromEnd bool) Position {
 	if value < 0 {
 		panic("linq: position must be non-negative")
@@ -17,16 +18,16 @@ func NewPosition(value int, fromEnd bool) Position {
 	return Position{value: value, fromEnd: fromEnd}
 }
 
-// PositionFromStart returns a Position counted from the start of a sequence. It
-// panics if value is negative.
-func PositionFromStart(value int) Position {
+// FromStart returns a Position counted from the start of a sequence. It panics
+// if value is negative.
+func FromStart(value int) Position {
 	return NewPosition(value, false)
 }
 
-// PositionFromEnd returns a Position counted from the end of a sequence.
-// PositionFromEnd(1) identifies the last element; PositionFromEnd(0) identifies the
-// position immediately after it. It panics if value is negative.
-func PositionFromEnd(value int) Position {
+// FromEnd returns a Position counted from the end of a sequence. FromEnd(1)
+// identifies the last element; FromEnd(0) identifies the position immediately
+// after it. It panics if value is negative.
+func FromEnd(value int) Position {
 	return NewPosition(value, true)
 }
 

--- a/index_test.go
+++ b/index_test.go
@@ -25,3 +25,57 @@ func TestIndexOf(t *testing.T) {
 		t.Errorf("IndexOf() expected -1 received %v", index)
 	}
 }
+
+func TestElementAt(t *testing.T) {
+	input := []int{10, 20, 30, 40, 50}
+	tests := []struct {
+		index  Index
+		want   int
+		wantOK bool
+	}{
+		{IndexFromStart(0), 10, true},
+		{IndexFromStart(2), 30, true},
+		{IndexFromStart(5), 0, false},
+		{IndexFromEnd(1), 50, true},
+		{IndexFromEnd(3), 30, true},
+		{IndexFromEnd(5), 10, true},
+		{IndexFromEnd(6), 0, false},
+		{IndexFromEnd(0), 0, false},
+	}
+
+	for _, test := range tests {
+		got, ok := FromSlice(input).ElementAt(test.index)
+		if got != test.want || ok != test.wantOK {
+			t.Errorf("ElementAt(%v)=%v,%v expected %v,%v",
+				test.index, got, ok, test.want, test.wantOK)
+		}
+	}
+}
+
+func TestElementAtStopsAtRequestedIndex(t *testing.T) {
+	pulled := 0
+	q := FromSlice([]int{10, 20, 30, 40}).Where(func(int) bool {
+		pulled++
+		return true
+	})
+
+	got, ok := q.ElementAt(IndexFromStart(2))
+	if !ok || got != 30 {
+		t.Fatalf("ElementAt(IndexFromStart(2))=%v,%v expected 30,true", got, ok)
+	}
+	if pulled != 3 {
+		t.Errorf("source pulled %d elements expected 3", pulled)
+	}
+}
+
+func TestIndexNegativeValuePanics(t *testing.T) {
+	constructors := []func(){
+		func() { NewIndex(-1, false) },
+		func() { NewIndex(-1, true) },
+		func() { IndexFromStart(-1) },
+		func() { IndexFromEnd(-1) },
+	}
+	for _, constructor := range constructors {
+		mustPanic(t, constructor)
+	}
+}

--- a/index_test.go
+++ b/index_test.go
@@ -33,14 +33,14 @@ func TestElementAt(t *testing.T) {
 		want   int
 		wantOK bool
 	}{
-		{PositionFromStart(0), 10, true},
-		{PositionFromStart(2), 30, true},
-		{PositionFromStart(5), 0, false},
-		{PositionFromEnd(1), 50, true},
-		{PositionFromEnd(3), 30, true},
-		{PositionFromEnd(5), 10, true},
-		{PositionFromEnd(6), 0, false},
-		{PositionFromEnd(0), 0, false},
+		{FromStart(0), 10, true},
+		{FromStart(2), 30, true},
+		{FromStart(5), 0, false},
+		{FromEnd(1), 50, true},
+		{FromEnd(3), 30, true},
+		{FromEnd(5), 10, true},
+		{FromEnd(6), 0, false},
+		{FromEnd(0), 0, false},
 	}
 
 	for _, test := range tests {
@@ -59,9 +59,9 @@ func TestElementAtStopsAtRequestedIndex(t *testing.T) {
 		return true
 	})
 
-	got, ok := q.ElementAt(PositionFromStart(2))
+	got, ok := q.ElementAt(FromStart(2))
 	if !ok || got != 30 {
-		t.Fatalf("ElementAt(PositionFromStart(2))=%v,%v expected 30,true", got, ok)
+		t.Fatalf("ElementAt(FromStart(2))=%v,%v expected 30,true", got, ok)
 	}
 	if pulled != 3 {
 		t.Errorf("source pulled %d elements expected 3", pulled)
@@ -72,8 +72,8 @@ func TestPositionNegativeValuePanics(t *testing.T) {
 	constructors := []func(){
 		func() { NewPosition(-1, false) },
 		func() { NewPosition(-1, true) },
-		func() { PositionFromStart(-1) },
-		func() { PositionFromEnd(-1) },
+		func() { FromStart(-1) },
+		func() { FromEnd(-1) },
 	}
 	for _, constructor := range constructors {
 		mustPanic(t, constructor)

--- a/index_test.go
+++ b/index_test.go
@@ -29,18 +29,18 @@ func TestIndexOf(t *testing.T) {
 func TestElementAt(t *testing.T) {
 	input := []int{10, 20, 30, 40, 50}
 	tests := []struct {
-		index  Index
+		index  Position
 		want   int
 		wantOK bool
 	}{
-		{IndexFromStart(0), 10, true},
-		{IndexFromStart(2), 30, true},
-		{IndexFromStart(5), 0, false},
-		{IndexFromEnd(1), 50, true},
-		{IndexFromEnd(3), 30, true},
-		{IndexFromEnd(5), 10, true},
-		{IndexFromEnd(6), 0, false},
-		{IndexFromEnd(0), 0, false},
+		{PositionFromStart(0), 10, true},
+		{PositionFromStart(2), 30, true},
+		{PositionFromStart(5), 0, false},
+		{PositionFromEnd(1), 50, true},
+		{PositionFromEnd(3), 30, true},
+		{PositionFromEnd(5), 10, true},
+		{PositionFromEnd(6), 0, false},
+		{PositionFromEnd(0), 0, false},
 	}
 
 	for _, test := range tests {
@@ -59,23 +59,51 @@ func TestElementAtStopsAtRequestedIndex(t *testing.T) {
 		return true
 	})
 
-	got, ok := q.ElementAt(IndexFromStart(2))
+	got, ok := q.ElementAt(PositionFromStart(2))
 	if !ok || got != 30 {
-		t.Fatalf("ElementAt(IndexFromStart(2))=%v,%v expected 30,true", got, ok)
+		t.Fatalf("ElementAt(PositionFromStart(2))=%v,%v expected 30,true", got, ok)
 	}
 	if pulled != 3 {
 		t.Errorf("source pulled %d elements expected 3", pulled)
 	}
 }
 
-func TestIndexNegativeValuePanics(t *testing.T) {
+func TestPositionNegativeValuePanics(t *testing.T) {
 	constructors := []func(){
-		func() { NewIndex(-1, false) },
-		func() { NewIndex(-1, true) },
-		func() { IndexFromStart(-1) },
-		func() { IndexFromEnd(-1) },
+		func() { NewPosition(-1, false) },
+		func() { NewPosition(-1, true) },
+		func() { PositionFromStart(-1) },
+		func() { PositionFromEnd(-1) },
 	}
 	for _, constructor := range constructors {
 		mustPanic(t, constructor)
+	}
+}
+
+func TestIndex(t *testing.T) {
+	want := []KeyValue[int, string]{
+		{Key: 0, Value: "zero"},
+		{Key: 1, Value: "one"},
+		{Key: 2, Value: "two"},
+	}
+
+	if q := Index(FromSlice([]string{"zero", "one", "two"})); !testQueryIteration(q, want) {
+		t.Errorf("Index()=%v expected %v", q.ToSlice(), want)
+	}
+	if got := Index(FromSlice([]string{})).ToSlice(); got != nil {
+		t.Errorf("Index(empty)=%v expected nil", got)
+	}
+}
+
+func TestIndexStopsWithConsumer(t *testing.T) {
+	pulled := 0
+	q := Index(FromSlice([]int{10, 20, 30}).Where(func(int) bool {
+		pulled++
+		return true
+	}))
+
+	q.Iterate(func(KeyValue[int, int]) bool { return false })
+	if pulled != 1 {
+		t.Errorf("Index pulled %d elements expected 1", pulled)
 	}
 }

--- a/join.go
+++ b/join.go
@@ -237,8 +237,8 @@ func buildJoinLookup[T any, TKey comparable](source Query[T], keySelector func(T
 	return lookup
 }
 
-// buildFullJoinGroups groups elements in first-seen key order. Nil keys remain
-// separate unmatched groups and stay out of the index.
+// buildFullJoinGroups groups elements in first-seen key order. Nil keys share
+// one unmatched group and stay out of the index.
 func buildFullJoinGroups[T any, TKey comparable](source Query[T],
 	keySelector func(T) TKey) ([][]T, map[TKey]int) {
 	keyKind := reflect.TypeFor[TKey]().Kind()
@@ -248,10 +248,15 @@ func buildFullJoinGroups[T any, TKey comparable](source Query[T],
 
 	var groups [][]T
 	index := make(map[TKey]int)
+	nilGroupIndex := -1
 	source.Iterate(func(item T) bool {
 		key := keySelector(item)
 		if (zeroIsNil && key == zeroKey) || (interfaceKey && isNilInterfaceKey(key)) {
-			groups = append(groups, []T{item})
+			if nilGroupIndex < 0 {
+				nilGroupIndex = len(groups)
+				groups = append(groups, nil)
+			}
+			groups[nilGroupIndex] = append(groups[nilGroupIndex], item)
 			return true
 		}
 

--- a/join.go
+++ b/join.go
@@ -27,16 +27,14 @@ func (q Query[T]) Join[TInner any, TKey comparable, TResult any](inner Query[TIn
 	return Query[TResult]{
 		Iterate: func(yield func(TResult) bool) {
 			innerLookup := buildJoinLookup(inner, innerKeySelector)
+			interfaceKey := reflect.TypeFor[TKey]().Kind() == reflect.Interface
 
 			q.Iterate(func(outerItem T) bool {
-				outerKey := outerKeySelector(outerItem)
-
-				if innerGroup, ok := innerLookup[outerKey]; ok {
-					for _, innerItem := range innerGroup {
-						result := resultSelector(outerItem, innerItem)
-						if !yield(result) {
-							return false
-						}
+				for _, innerItem := range joinGroupFor(innerLookup,
+					outerKeySelector(outerItem), interfaceKey) {
+					result := resultSelector(outerItem, innerItem)
+					if !yield(result) {
+						return false
 					}
 				}
 				return true
@@ -60,14 +58,15 @@ func (q Query[T]) LeftJoin[TInner any, TKey comparable, TResult any](inner Query
 	return Query[TResult]{
 		Iterate: func(yield func(TResult) bool) {
 			var innerLookup map[TKey][]TInner
+			interfaceKey := reflect.TypeFor[TKey]().Kind() == reflect.Interface
 
 			q.Iterate(func(outerItem T) bool {
 				if innerLookup == nil {
 					innerLookup = buildJoinLookup(inner, innerKeySelector)
 				}
 
-				innerGroup, ok := innerLookup[outerKeySelector(outerItem)]
-				if !ok {
+				innerGroup := joinGroupFor(innerLookup, outerKeySelector(outerItem), interfaceKey)
+				if len(innerGroup) == 0 {
 					var zero TInner
 					return yield(resultSelector(outerItem, zero))
 				}
@@ -100,14 +99,15 @@ func (q Query[T]) RightJoin[TInner any, TKey comparable, TResult any](inner Quer
 	return Query[TResult]{
 		Iterate: func(yield func(TResult) bool) {
 			var outerLookup map[TKey][]T
+			interfaceKey := reflect.TypeFor[TKey]().Kind() == reflect.Interface
 
 			inner.Iterate(func(innerItem TInner) bool {
 				if outerLookup == nil {
 					outerLookup = buildJoinLookup(q, outerKeySelector)
 				}
 
-				outerGroup, ok := outerLookup[innerKeySelector(innerItem)]
-				if !ok {
+				outerGroup := joinGroupFor(outerLookup, innerKeySelector(innerItem), interfaceKey)
+				if len(outerGroup) == 0 {
 					var zero T
 					return yield(resultSelector(zero, innerItem))
 				}
@@ -136,74 +136,35 @@ func (q Query[T]) FullJoin[TInner any, TKey comparable, TResult any](inner Query
 	resultSelector func(outer T, inner TInner) TResult) Query[TResult] {
 	return Query[TResult]{
 		Iterate: func(yield func(TResult) bool) {
-			type group struct {
-				items   []TInner
-				matched bool
-			}
+			innerGroups, innerLookup := buildFullJoinGroups(inner, innerKeySelector)
+			matched := make([]bool, len(innerGroups))
+			interfaceKey := reflect.TypeFor[TKey]().Kind() == reflect.Interface
 
-			keyKind := reflect.TypeFor[TKey]().Kind()
-			innerLookup := make(map[TKey]int)
-			var innerGroups []group
-			inner.Iterate(func(item TInner) bool {
-				key := innerKeySelector(item)
-				if isNilJoinKey(key, keyKind) {
-					// Never matches, not even another nil key, so it gets a
-					// group of its own rather than sharing one.
-					innerGroups = append(innerGroups, group{items: []TInner{item}})
-					return true
-				}
+			noMatch := make([]TInner, 1)
 
-				groupIndex, ok := innerLookup[key]
-				if !ok {
-					groupIndex = len(innerGroups)
-					innerLookup[key] = groupIndex
-					innerGroups = append(innerGroups, group{})
-				}
-				innerGroups[groupIndex].items = append(innerGroups[groupIndex].items, item)
-				return true
-			})
-
-			stopped := false
-
-			q.Iterate(func(outerItem T) bool {
+			for outerItem := range q.Iterate {
+				innerItems := noMatch
 				outerKey := outerKeySelector(outerItem)
-				innerGroupIndex := -1
-				if !isNilJoinKey(outerKey, keyKind) {
+				if !interfaceKey || !isNilInterfaceKey(outerKey) {
 					if index, ok := innerLookup[outerKey]; ok {
-						innerGroupIndex = index
+						matched[index] = true
+						innerItems = innerGroups[index]
 					}
-				}
-				if innerGroupIndex < 0 {
-					var zero TInner
-					if !yield(resultSelector(outerItem, zero)) {
-						stopped = true
-						return false
-					}
-					return true
 				}
 
-				innerGroup := &innerGroups[innerGroupIndex]
-				innerGroup.matched = true
-				for _, innerItem := range innerGroup.items {
+				for _, innerItem := range innerItems {
 					if !yield(resultSelector(outerItem, innerItem)) {
-						stopped = true
-						return false
+						return
 					}
 				}
-				return true
-			})
-
-			if stopped {
-				return
 			}
 
 			var zero T
-			for i := range innerGroups {
-				innerGroup := &innerGroups[i]
-				if innerGroup.matched {
+			for i, innerGroup := range innerGroups {
+				if matched[i] {
 					continue
 				}
-				for _, innerItem := range innerGroup.items {
+				for _, innerItem := range innerGroup {
 					if !yield(resultSelector(zero, innerItem)) {
 						return
 					}
@@ -213,24 +174,28 @@ func (q Query[T]) FullJoin[TInner any, TKey comparable, TResult any](inner Query
 	}
 }
 
-func isNilJoinKey[TKey comparable](key TKey, kind reflect.Kind) bool {
-	switch kind {
-	case reflect.Chan, reflect.Pointer, reflect.UnsafePointer:
-		var zero TKey
-		return key == zero
-	case reflect.Interface:
-		value := reflect.ValueOf(key)
-		if !value.IsValid() {
-			return true
-		}
-		switch value.Kind() {
-		case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Slice:
-			return value.IsNil()
-		case reflect.UnsafePointer:
-			return value.IsZero()
-		}
+// isNilInterfaceKey reports whether an interface key is nil or holds a typed nil.
+func isNilInterfaceKey(key any) bool {
+	value := reflect.ValueOf(key)
+	if !value.IsValid() {
+		return true
+	}
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	case reflect.UnsafePointer:
+		return value.IsZero()
 	}
 	return false
+}
+
+// joinGroupFor returns nil for interface keys that hold a typed nil, which
+// may be unhashable and must not reach a map lookup.
+func joinGroupFor[T any, TKey comparable](lookup map[TKey][]T, key TKey, interfaceKey bool) []T {
+	if interfaceKey && isNilInterfaceKey(key) {
+		return nil
+	}
+	return lookup[key]
 }
 
 // buildJoinLookup indexes non-nil keys. .NET LINQ joins do not match null keys.
@@ -254,7 +219,7 @@ func buildJoinLookup[T any, TKey comparable](source Query[T], keySelector func(T
 		// one path that pays for reflection per element.
 		source.Iterate(func(item T) bool {
 			key := keySelector(item)
-			if isNilJoinKey(key, reflect.Interface) {
+			if isNilInterfaceKey(key) {
 				return true
 			}
 			lookup[key] = append(lookup[key], item)
@@ -270,4 +235,34 @@ func buildJoinLookup[T any, TKey comparable](source Query[T], keySelector func(T
 		})
 	}
 	return lookup
+}
+
+// buildFullJoinGroups groups elements in first-seen key order. Nil keys remain
+// separate unmatched groups and stay out of the index.
+func buildFullJoinGroups[T any, TKey comparable](source Query[T],
+	keySelector func(T) TKey) ([][]T, map[TKey]int) {
+	keyKind := reflect.TypeFor[TKey]().Kind()
+	zeroIsNil := keyKind == reflect.Chan || keyKind == reflect.Pointer || keyKind == reflect.UnsafePointer
+	interfaceKey := keyKind == reflect.Interface
+	var zeroKey TKey
+
+	var groups [][]T
+	index := make(map[TKey]int)
+	source.Iterate(func(item T) bool {
+		key := keySelector(item)
+		if (zeroIsNil && key == zeroKey) || (interfaceKey && isNilInterfaceKey(key)) {
+			groups = append(groups, []T{item})
+			return true
+		}
+
+		i, ok := index[key]
+		if !ok {
+			i = len(groups)
+			index[key] = i
+			groups = append(groups, nil)
+		}
+		groups[i] = append(groups[i], item)
+		return true
+	})
+	return groups, index
 }

--- a/join.go
+++ b/join.go
@@ -46,7 +46,8 @@ func (q Query[T]) Join[TInner any, TKey comparable, TResult any](inner Query[TIn
 // LeftJoin correlates two collections by key while retaining every element of
 // the outer collection. When an outer element has no match — a nil key never
 // matches, not even another nil key — resultSelector is called with the zero
-// value of TInner.
+// value of TInner, which it cannot tell apart from a matched element that is
+// itself the zero value.
 //
 // Inner is indexed from the first outer element, so an empty outer never reads
 // inner. An empty inner has no such shortcut: every outer element still owes a
@@ -85,7 +86,8 @@ func (q Query[T]) LeftJoin[TInner any, TKey comparable, TResult any](inner Query
 // RightJoin correlates two collections by key while retaining every element
 // of the inner collection. When an inner element has no match — a nil key never
 // matches, not even another nil key — resultSelector is called with the zero
-// value of T.
+// value of T, which it cannot tell apart from a matched element that is itself
+// the zero value.
 //
 // Outer is indexed from the first inner element, so an empty inner never reads
 // outer. An empty outer has no such shortcut: every inner element still owes a
@@ -94,8 +96,7 @@ func (q Query[T]) RightJoin[TInner any, TKey comparable, TResult any](inner Quer
 	outerKeySelector func(T) TKey,
 	innerKeySelector func(TInner) TKey,
 	resultSelector func(outer T, inner TInner) TResult) Query[TResult] {
-	// ponytail: Delegating to LeftJoin is shorter but adds an argument-swapping
-	// call per result (~10% in paired benchmarks); collapse if that call becomes free.
+	// Keep the mirrored implementation to avoid an argument-swapping call per result.
 	return Query[TResult]{
 		Iterate: func(yield func(TResult) bool) {
 			var outerLookup map[TKey][]T
@@ -126,7 +127,8 @@ func (q Query[T]) RightJoin[TInner any, TKey comparable, TResult any](inner Quer
 // FullJoin correlates two collections by key while retaining every element of
 // both collections. When an element has no match — a nil key never matches,
 // not even another nil key — resultSelector is called with the zero value for
-// the missing side.
+// the missing side, which it cannot tell apart from a matched element that is
+// itself the zero value.
 //
 // Inner is indexed before outer is read. Results for outer elements come
 // first, followed by unmatched inner groups in first-seen key order.

--- a/join.go
+++ b/join.go
@@ -123,6 +123,116 @@ func (q Query[T]) RightJoin[TInner any, TKey comparable, TResult any](inner Quer
 	}
 }
 
+// FullJoin correlates two collections by key while retaining every element of
+// both collections. When an element has no match — a nil key never matches,
+// not even another nil key — resultSelector is called with the zero value for
+// the missing side.
+//
+// Inner is indexed before outer is read. Results for outer elements come
+// first, followed by unmatched inner groups in first-seen key order.
+func (q Query[T]) FullJoin[TInner any, TKey comparable, TResult any](inner Query[TInner],
+	outerKeySelector func(T) TKey,
+	innerKeySelector func(TInner) TKey,
+	resultSelector func(outer T, inner TInner) TResult) Query[TResult] {
+	return Query[TResult]{
+		Iterate: func(yield func(TResult) bool) {
+			type group struct {
+				items   []TInner
+				matched bool
+			}
+
+			keyKind := reflect.TypeFor[TKey]().Kind()
+			innerLookup := make(map[TKey]int)
+			var innerGroups []group
+			inner.Iterate(func(item TInner) bool {
+				key := innerKeySelector(item)
+				if isNilJoinKey(key, keyKind) {
+					// Never matches, not even another nil key, so it gets a
+					// group of its own rather than sharing one.
+					innerGroups = append(innerGroups, group{items: []TInner{item}})
+					return true
+				}
+
+				groupIndex, ok := innerLookup[key]
+				if !ok {
+					groupIndex = len(innerGroups)
+					innerLookup[key] = groupIndex
+					innerGroups = append(innerGroups, group{})
+				}
+				innerGroups[groupIndex].items = append(innerGroups[groupIndex].items, item)
+				return true
+			})
+
+			stopped := false
+
+			q.Iterate(func(outerItem T) bool {
+				outerKey := outerKeySelector(outerItem)
+				innerGroupIndex := -1
+				if !isNilJoinKey(outerKey, keyKind) {
+					if index, ok := innerLookup[outerKey]; ok {
+						innerGroupIndex = index
+					}
+				}
+				if innerGroupIndex < 0 {
+					var zero TInner
+					if !yield(resultSelector(outerItem, zero)) {
+						stopped = true
+						return false
+					}
+					return true
+				}
+
+				innerGroup := &innerGroups[innerGroupIndex]
+				innerGroup.matched = true
+				for _, innerItem := range innerGroup.items {
+					if !yield(resultSelector(outerItem, innerItem)) {
+						stopped = true
+						return false
+					}
+				}
+				return true
+			})
+
+			if stopped {
+				return
+			}
+
+			var zero T
+			for i := range innerGroups {
+				innerGroup := &innerGroups[i]
+				if innerGroup.matched {
+					continue
+				}
+				for _, innerItem := range innerGroup.items {
+					if !yield(resultSelector(zero, innerItem)) {
+						return
+					}
+				}
+			}
+		},
+	}
+}
+
+func isNilJoinKey[TKey comparable](key TKey, kind reflect.Kind) bool {
+	switch kind {
+	case reflect.Chan, reflect.Pointer, reflect.UnsafePointer:
+		var zero TKey
+		return key == zero
+	case reflect.Interface:
+		value := reflect.ValueOf(key)
+		if !value.IsValid() {
+			return true
+		}
+		switch value.Kind() {
+		case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Slice:
+			return value.IsNil()
+		case reflect.UnsafePointer:
+			return value.IsZero()
+		}
+	}
+	return false
+}
+
 // buildJoinLookup indexes non-nil keys. .NET LINQ joins do not match null keys.
 func buildJoinLookup[T any, TKey comparable](source Query[T], keySelector func(T) TKey) map[TKey][]T {
 	lookup := make(map[TKey][]T)
@@ -144,20 +254,8 @@ func buildJoinLookup[T any, TKey comparable](source Query[T], keySelector func(T
 		// one path that pays for reflection per element.
 		source.Iterate(func(item T) bool {
 			key := keySelector(item)
-			value := reflect.ValueOf(key)
-			if !value.IsValid() {
+			if isNilJoinKey(key, reflect.Interface) {
 				return true
-			}
-			switch value.Kind() {
-			case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Slice:
-				if value.IsNil() {
-					return true
-				}
-			case reflect.UnsafePointer:
-				// Not IsNil: reflect panics on it for this kind.
-				if value.IsZero() {
-					return true
-				}
 			}
 			lookup[key] = append(lookup[key], item)
 			return true

--- a/join.go
+++ b/join.go
@@ -1,5 +1,7 @@
 package linq
 
+import "reflect"
+
 // Join correlates the elements of two collections based on matching keys.
 //
 // A join refers to the operation of correlating the elements of two sources of
@@ -14,6 +16,9 @@ package linq
 //
 // Join preserves the order of the elements of outer collection, and for each of
 // these elements, the order of the matching elements of inner.
+//
+// Elements whose key is nil take no part in the join: like .NET LINQ, Join
+// never matches a nil key, not even against another nil key.
 func (q Query[T]) Join[TInner any, TKey comparable, TResult any](inner Query[TInner],
 	outerKeySelector func(T) TKey,
 	innerKeySelector func(TInner) TKey,
@@ -21,12 +26,7 @@ func (q Query[T]) Join[TInner any, TKey comparable, TResult any](inner Query[TIn
 
 	return Query[TResult]{
 		Iterate: func(yield func(TResult) bool) {
-			innerLookup := make(map[TKey][]TInner)
-			inner.Iterate(func(innerItem TInner) bool {
-				innerKey := innerKeySelector(innerItem)
-				innerLookup[innerKey] = append(innerLookup[innerKey], innerItem)
-				return true
-			})
+			innerLookup := buildJoinLookup(inner, innerKeySelector)
 
 			q.Iterate(func(outerItem T) bool {
 				outerKey := outerKeySelector(outerItem)
@@ -43,4 +43,133 @@ func (q Query[T]) Join[TInner any, TKey comparable, TResult any](inner Query[TIn
 			})
 		},
 	}
+}
+
+// LeftJoin correlates two collections by key while retaining every element of
+// the outer collection. When an outer element has no match — a nil key never
+// matches, not even another nil key — resultSelector is called with the zero
+// value of TInner.
+//
+// Inner is indexed from the first outer element, so an empty outer never reads
+// inner. An empty inner has no such shortcut: every outer element still owes a
+// result.
+func (q Query[T]) LeftJoin[TInner any, TKey comparable, TResult any](inner Query[TInner],
+	outerKeySelector func(T) TKey,
+	innerKeySelector func(TInner) TKey,
+	resultSelector func(outer T, inner TInner) TResult) Query[TResult] {
+	return Query[TResult]{
+		Iterate: func(yield func(TResult) bool) {
+			var innerLookup map[TKey][]TInner
+
+			q.Iterate(func(outerItem T) bool {
+				if innerLookup == nil {
+					innerLookup = buildJoinLookup(inner, innerKeySelector)
+				}
+
+				innerGroup, ok := innerLookup[outerKeySelector(outerItem)]
+				if !ok {
+					var zero TInner
+					return yield(resultSelector(outerItem, zero))
+				}
+
+				for _, innerItem := range innerGroup {
+					if !yield(resultSelector(outerItem, innerItem)) {
+						return false
+					}
+				}
+				return true
+			})
+		},
+	}
+}
+
+// RightJoin correlates two collections by key while retaining every element
+// of the inner collection. When an inner element has no match — a nil key never
+// matches, not even another nil key — resultSelector is called with the zero
+// value of T.
+//
+// Outer is indexed from the first inner element, so an empty inner never reads
+// outer. An empty outer has no such shortcut: every inner element still owes a
+// result.
+func (q Query[T]) RightJoin[TInner any, TKey comparable, TResult any](inner Query[TInner],
+	outerKeySelector func(T) TKey,
+	innerKeySelector func(TInner) TKey,
+	resultSelector func(outer T, inner TInner) TResult) Query[TResult] {
+	// ponytail: Delegating to LeftJoin is shorter but adds an argument-swapping
+	// call per result (~10% in paired benchmarks); collapse if that call becomes free.
+	return Query[TResult]{
+		Iterate: func(yield func(TResult) bool) {
+			var outerLookup map[TKey][]T
+
+			inner.Iterate(func(innerItem TInner) bool {
+				if outerLookup == nil {
+					outerLookup = buildJoinLookup(q, outerKeySelector)
+				}
+
+				outerGroup, ok := outerLookup[innerKeySelector(innerItem)]
+				if !ok {
+					var zero T
+					return yield(resultSelector(zero, innerItem))
+				}
+
+				for _, outerItem := range outerGroup {
+					if !yield(resultSelector(outerItem, innerItem)) {
+						return false
+					}
+				}
+				return true
+			})
+		},
+	}
+}
+
+// buildJoinLookup indexes non-nil keys. .NET LINQ joins do not match null keys.
+func buildJoinLookup[T any, TKey comparable](source Query[T], keySelector func(T) TKey) map[TKey][]T {
+	lookup := make(map[TKey][]T)
+	switch reflect.TypeFor[TKey]().Kind() {
+	case reflect.Chan, reflect.Pointer, reflect.UnsafePointer:
+		// Nilable statically, so the zero value is the only nil there is.
+		var zero TKey
+		source.Iterate(func(item T) bool {
+			key := keySelector(item)
+			if key != zero {
+				lookup[key] = append(lookup[key], item)
+			}
+			return true
+		})
+
+	case reflect.Interface:
+		// A typed nil pointer in an interface is not the nil interface, so
+		// nothing short of the dynamic value can tell them apart. This is the
+		// one path that pays for reflection per element.
+		source.Iterate(func(item T) bool {
+			key := keySelector(item)
+			value := reflect.ValueOf(key)
+			if !value.IsValid() {
+				return true
+			}
+			switch value.Kind() {
+			case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Slice:
+				if value.IsNil() {
+					return true
+				}
+			case reflect.UnsafePointer:
+				// Not IsNil: reflect panics on it for this kind.
+				if value.IsZero() {
+					return true
+				}
+			}
+			lookup[key] = append(lookup[key], item)
+			return true
+		})
+
+	default:
+		// No value of TKey can be nil.
+		source.Iterate(func(item T) bool {
+			key := keySelector(item)
+			lookup[key] = append(lookup[key], item)
+			return true
+		})
+	}
+	return lookup
 }

--- a/join_test.go
+++ b/join_test.go
@@ -248,6 +248,38 @@ func TestJoinsIgnoreNilKeys(t *testing.T) {
 	}
 }
 
+func TestJoinsIgnoreNonHashableNilKeys(t *testing.T) {
+	type item struct {
+		key   any
+		value string
+	}
+	key := func(item item) any { return item.key }
+	// The searched side must hold a real key: on an empty lookup Go answers
+	// before it hashes, which hides an unhashable key.
+	keyed := FromSlice([]item{{key: 1, value: "keyed"}})
+	boxedNil := FromSlice([]item{{key: []int(nil), value: "nil"}})
+	pair := func(outer, inner item) string { return outer.value + ":" + inner.value }
+
+	if got := boxedNil.Join(keyed, key, key, pair).ToSlice(); got != nil {
+		t.Errorf("Join(boxed nil key)=%v expected nil", got)
+	}
+	if q := boxedNil.LeftJoin(keyed, key, key, pair); !testQueryIteration(q, []string{"nil:"}) {
+		t.Errorf("LeftJoin(boxed nil key)=%v expected [nil:]", q.ToSlice())
+	}
+	if q := keyed.RightJoin(boxedNil, key, key, pair); !testQueryIteration(q, []string{":nil"}) {
+		t.Errorf("RightJoin(boxed nil key)=%v expected [:nil]", q.ToSlice())
+	}
+	if q := boxedNil.GroupJoin(keyed, key, key, func(_ item, inner []item) int {
+		return len(inner)
+	}); !testQueryIteration(q, []int{0}) {
+		t.Errorf("GroupJoin(boxed nil key)=%v expected [0]", q.ToSlice())
+	}
+	want := []string{"nil:", ":keyed"}
+	if q := boxedNil.FullJoin(keyed, key, key, pair); !testQueryIteration(q, want) {
+		t.Errorf("FullJoin(boxed nil key)=%v expected %v", q.ToSlice(), want)
+	}
+}
+
 func TestOuterJoinDoesNotReadOtherSideWhenRetainedSideIsEmpty(t *testing.T) {
 	leftPulled, rightPulled := 0, 0
 	left := FromSlice([]int{1}).Where(func(int) bool {

--- a/join_test.go
+++ b/join_test.go
@@ -58,3 +58,171 @@ func TestJoin_TypeChanging(t *testing.T) {
 		t.Errorf("Join()=%v expected %v", toSlice(q), want)
 	}
 }
+
+func TestLeftJoin(t *testing.T) {
+	type pair struct {
+		outer int
+		inner int
+	}
+
+	q := FromSlice([]int{0, 1, 2, 3, 4}).LeftJoin(
+		FromSlice([]int{1, 2, 1, 4, 7, 2}),
+		func(i int) int { return i },
+		func(i int) int { return i },
+		func(outer, inner int) pair { return pair{outer, inner} },
+	)
+	want := []pair{{0, 0}, {1, 1}, {1, 1}, {2, 2}, {2, 2}, {3, 0}, {4, 4}}
+	if !testQueryIteration(q, want) {
+		t.Errorf("LeftJoin()=%v expected %v", q.ToSlice(), want)
+	}
+}
+
+func TestRightJoin(t *testing.T) {
+	type pair struct {
+		outer int
+		inner int
+	}
+
+	q := FromSlice([]int{0, 1, 2, 3, 4}).RightJoin(
+		FromSlice([]int{1, 2, 1, 4, 7, 2}),
+		func(i int) int { return i },
+		func(i int) int { return i },
+		func(outer, inner int) pair { return pair{outer, inner} },
+	)
+	want := []pair{{1, 1}, {2, 2}, {1, 1}, {4, 4}, {0, 7}, {2, 2}}
+	if !testQueryIteration(q, want) {
+		t.Errorf("RightJoin()=%v expected %v", q.ToSlice(), want)
+	}
+}
+
+func TestJoinsIgnoreNilKeys(t *testing.T) {
+	type item struct {
+		key   *int
+		value string
+	}
+	outer := FromSlice([]item{{value: "outer"}})
+	inner := FromSlice([]item{{value: "inner"}})
+	key := func(item item) *int { return item.key }
+
+	if got := outer.Join(inner, key, key, func(outer, inner item) string {
+		return outer.value + inner.value
+	}).ToSlice(); got != nil {
+		t.Errorf("Join(nil keys)=%v expected nil", got)
+	}
+
+	if q := outer.LeftJoin(inner, key, key, func(outer, inner item) string {
+		return inner.value
+	}); !testQueryIteration(q, []string{""}) {
+		t.Errorf("LeftJoin(nil keys)=%v expected unmatched inner", q.ToSlice())
+	}
+
+	if q := outer.RightJoin(inner, key, key, func(outer, inner item) string {
+		return outer.value
+	}); !testQueryIteration(q, []string{""}) {
+		t.Errorf("RightJoin(nil keys)=%v expected unmatched outer", q.ToSlice())
+	}
+
+	if q := outer.GroupJoin(inner, key, key, func(_ item, inner []item) int {
+		return len(inner)
+	}); !testQueryIteration(q, []int{0}) {
+		t.Errorf("GroupJoin(nil keys)=%v expected [0]", q.ToSlice())
+	}
+
+	interfaceLookup := buildJoinLookup(inner, func(item item) any { return item.key })
+	if len(interfaceLookup) != 0 {
+		t.Errorf("join lookup with a typed nil interface key=%v expected empty", interfaceLookup)
+	}
+}
+
+func TestOuterJoinDoesNotReadOtherSideWhenRetainedSideIsEmpty(t *testing.T) {
+	leftPulled, rightPulled := 0, 0
+	left := FromSlice([]int{1}).Where(func(int) bool {
+		leftPulled++
+		return true
+	})
+	right := FromSlice([]int{1}).Where(func(int) bool {
+		rightPulled++
+		return true
+	})
+
+	FromSlice([]int{}).LeftJoin(
+		right,
+		func(i int) int { return i },
+		func(i int) int { return i },
+		func(outer, inner int) int { return outer + inner },
+	).ToSlice()
+	left.RightJoin(
+		FromSlice([]int{}),
+		func(i int) int { return i },
+		func(i int) int { return i },
+		func(outer, inner int) int { return outer + inner },
+	).ToSlice()
+
+	if rightPulled != 0 || leftPulled != 0 {
+		t.Errorf("empty retained side pulled left=%d right=%d expected 0,0", leftPulled, rightPulled)
+	}
+}
+
+func TestLeftJoinStopsWithConsumer(t *testing.T) {
+	outerPulled, innerPulled := 0, 0
+	outer := FromSlice([]int{1, 2, 3}).Where(func(int) bool {
+		outerPulled++
+		return true
+	})
+	inner := FromSlice([]int{1, 2, 3}).Where(func(int) bool {
+		innerPulled++
+		return true
+	})
+
+	outer.LeftJoin(
+		inner,
+		func(i int) int { return i },
+		func(i int) int { return i },
+		func(outer, inner int) int { return outer + inner },
+	).Iterate(func(int) bool { return false })
+
+	if outerPulled != 1 || innerPulled != 3 {
+		t.Errorf("LeftJoin pulled outer=%d inner=%d expected 1,3", outerPulled, innerPulled)
+	}
+}
+
+func TestLeftJoinWithEmptyInner(t *testing.T) {
+	outerPulled := 0
+	outer := FromSlice([]int{1, 2, 3}).Where(func(int) bool {
+		outerPulled++
+		return true
+	})
+
+	q := outer.LeftJoin(
+		FromSlice([]int{}),
+		func(i int) int { return i },
+		func(i int) int { return i },
+		func(outer, inner int) KeyValue[int, int] {
+			return KeyValue[int, int]{outer, inner}
+		},
+	)
+
+	want := []KeyValue[int, int]{{1, 0}, {2, 0}, {3, 0}}
+	if !testQueryIteration(q, want) {
+		t.Errorf("LeftJoin(empty inner)=%v expected %v", q.ToSlice(), want)
+	}
+	if outerPulled == 0 {
+		t.Error("LeftJoin(empty inner) skipped outer; every outer element owes a result")
+	}
+}
+
+func TestRightJoinWithEmptyOuter(t *testing.T) {
+	q := FromSlice([]int{}).RightJoin(
+		FromSlice([]int{1, 2, 3}),
+		func(i int) int { return i },
+		func(i int) int { return i },
+		func(outer, inner int) KeyValue[int, int] {
+			return KeyValue[int, int]{outer, inner}
+		},
+	)
+
+	want := []KeyValue[int, int]{{0, 1}, {0, 2}, {0, 3}}
+	if !testQueryIteration(q, want) {
+		t.Errorf("RightJoin(empty outer)=%v expected %v", q.ToSlice(), want)
+	}
+}

--- a/join_test.go
+++ b/join_test.go
@@ -95,6 +95,82 @@ func TestRightJoin(t *testing.T) {
 	}
 }
 
+func TestFullJoin(t *testing.T) {
+	type pair struct {
+		outer int
+		inner int
+	}
+
+	q := FromSlice([]int{0, 1, 2, 3, 4}).FullJoin(
+		FromSlice([]int{1, 2, 1, 4, 7, 6, 7, 2}),
+		func(i int) int { return i },
+		func(i int) int { return i },
+		func(outer, inner int) pair { return pair{outer, inner} },
+	)
+	want := []pair{
+		{0, 0}, {1, 1}, {1, 1}, {2, 2}, {2, 2}, {3, 0}, {4, 4},
+		{0, 7}, {0, 7}, {0, 6},
+	}
+	if !testQueryIteration(q, want) {
+		t.Errorf("FullJoin()=%v expected %v", q.ToSlice(), want)
+	}
+}
+
+func TestFullJoinWithEmptySide(t *testing.T) {
+	type pair struct {
+		outer int
+		inner int
+	}
+	tests := []struct {
+		name         string
+		outer, inner []int
+		want         []pair
+	}{
+		{name: "both", want: nil},
+		{name: "inner", inner: []int{1, 2}, want: []pair{{0, 1}, {0, 2}}},
+		{name: "outer", outer: []int{1, 2}, want: []pair{{1, 0}, {2, 0}}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			q := FromSlice(test.outer).FullJoin(
+				FromSlice(test.inner),
+				func(i int) int { return i },
+				func(i int) int { return i },
+				func(outer, inner int) pair { return pair{outer, inner} },
+			)
+			if !testQueryIteration(q, test.want) {
+				t.Errorf("FullJoin()=%v expected %v", q.ToSlice(), test.want)
+			}
+		})
+	}
+}
+
+func TestFullJoinKeepsNilKeyOrder(t *testing.T) {
+	type item struct {
+		key   *int
+		value string
+	}
+	key := 1
+	inner := FromSlice([]item{
+		{value: "nilA"},
+		{key: &key, value: "keyed"},
+		{value: "nilB"},
+	})
+
+	// A nil key never matches, not even another nil key, so the two nil-key
+	// elements stay where they were seen instead of batching together.
+	q := FromSlice([]item{}).FullJoin(inner,
+		func(item item) *int { return item.key },
+		func(item item) *int { return item.key },
+		func(_ item, inner item) string { return inner.value },
+	)
+	want := []string{"nilA", "keyed", "nilB"}
+	if !testQueryIteration(q, want) {
+		t.Errorf("FullJoin(mixed nil keys)=%v expected %v", q.ToSlice(), want)
+	}
+}
+
 func TestJoinsIgnoreNilKeys(t *testing.T) {
 	type item struct {
 		key   *int
@@ -122,6 +198,29 @@ func TestJoinsIgnoreNilKeys(t *testing.T) {
 		t.Errorf("RightJoin(nil keys)=%v expected unmatched outer", q.ToSlice())
 	}
 
+	fullWant := []string{"outer:", ":inner"}
+	if q := outer.FullJoin(inner, key, key, func(outer, inner item) string {
+		return outer.value + ":" + inner.value
+	}); !testQueryIteration(q, fullWant) {
+		t.Errorf("FullJoin(nil keys)=%v expected %v", q.ToSlice(), fullWant)
+	}
+	if q := outer.FullJoin(
+		inner,
+		func(item item) any { return item.key },
+		func(item item) any { return item.key },
+		func(outer, inner item) string { return outer.value + ":" + inner.value },
+	); !testQueryIteration(q, fullWant) {
+		t.Errorf("FullJoin(typed nil interface keys)=%v expected %v", q.ToSlice(), fullWant)
+	}
+	if q := outer.FullJoin(
+		inner,
+		func(item) any { return nil },
+		func(item) any { return nil },
+		func(outer, inner item) string { return outer.value + ":" + inner.value },
+	); !testQueryIteration(q, fullWant) {
+		t.Errorf("FullJoin(untyped nil interface keys)=%v expected %v", q.ToSlice(), fullWant)
+	}
+
 	if q := outer.GroupJoin(inner, key, key, func(_ item, inner []item) int {
 		return len(inner)
 	}); !testQueryIteration(q, []int{0}) {
@@ -131,6 +230,21 @@ func TestJoinsIgnoreNilKeys(t *testing.T) {
 	interfaceLookup := buildJoinLookup(inner, func(item item) any { return item.key })
 	if len(interfaceLookup) != 0 {
 		t.Errorf("join lookup with a typed nil interface key=%v expected empty", interfaceLookup)
+	}
+
+	type boxedItem struct {
+		key   any
+		value string
+	}
+	boxedOuter := FromSlice([]boxedItem{{key: []int(nil), value: "outer"}})
+	boxedInner := FromSlice([]boxedItem{{key: map[string]int(nil), value: "inner"}})
+	if q := boxedOuter.FullJoin(
+		boxedInner,
+		func(item boxedItem) any { return item.key },
+		func(item boxedItem) any { return item.key },
+		func(outer, inner boxedItem) string { return outer.value + ":" + inner.value },
+	); !testQueryIteration(q, fullWant) {
+		t.Errorf("FullJoin(non-comparable typed nil interface keys)=%v expected %v", q.ToSlice(), fullWant)
 	}
 }
 
@@ -183,6 +297,33 @@ func TestLeftJoinStopsWithConsumer(t *testing.T) {
 
 	if outerPulled != 1 || innerPulled != 3 {
 		t.Errorf("LeftJoin pulled outer=%d inner=%d expected 1,3", outerPulled, innerPulled)
+	}
+}
+
+func TestFullJoinStopsWithConsumer(t *testing.T) {
+	outerPulled, innerPulled, results := 0, 0, 0
+	outer := FromSlice([]int{1, 2, 3}).Where(func(int) bool {
+		outerPulled++
+		return true
+	})
+	inner := FromSlice([]int{1, 2, 3}).Where(func(int) bool {
+		innerPulled++
+		return true
+	})
+
+	outer.FullJoin(
+		inner,
+		func(i int) int { return i },
+		func(i int) int { return i },
+		func(outer, inner int) int {
+			results++
+			return outer + inner
+		},
+	).Iterate(func(int) bool { return false })
+
+	if outerPulled != 1 || innerPulled != 3 || results != 1 {
+		t.Errorf("FullJoin pulled outer=%d inner=%d results=%d expected 1,3,1",
+			outerPulled, innerPulled, results)
 	}
 }
 

--- a/join_test.go
+++ b/join_test.go
@@ -146,7 +146,7 @@ func TestFullJoinWithEmptySide(t *testing.T) {
 	}
 }
 
-func TestFullJoinKeepsNilKeyOrder(t *testing.T) {
+func TestFullJoinGroupsNilKeys(t *testing.T) {
 	type item struct {
 		key   *int
 		value string
@@ -158,14 +158,13 @@ func TestFullJoinKeepsNilKeyOrder(t *testing.T) {
 		{value: "nilB"},
 	})
 
-	// A nil key never matches, not even another nil key, so the two nil-key
-	// elements stay where they were seen instead of batching together.
+	// Nil keys never match, but unmatched inner nils share one first-seen group.
 	q := FromSlice([]item{}).FullJoin(inner,
 		func(item item) *int { return item.key },
 		func(item item) *int { return item.key },
 		func(_ item, inner item) string { return inner.value },
 	)
-	want := []string{"nilA", "keyed", "nilB"}
+	want := []string{"nilA", "nilB", "keyed"}
 	if !testQueryIteration(q, want) {
 		t.Errorf("FullJoin(mixed nil keys)=%v expected %v", q.ToSlice(), want)
 	}

--- a/numeric.go
+++ b/numeric.go
@@ -211,6 +211,42 @@ func Min[T cmp.Ordered](q Query[T]) (T, bool) {
 	return r, found
 }
 
+// MaxWith returns the maximum element according to compare and a boolean
+// reporting whether the collection was non-empty. compare follows the same
+// convention as cmp.Compare: a negative result means the first value is less
+// than the second. If multiple elements compare equal, MaxWith returns the
+// first one.
+func (q Query[T]) MaxWith(compare func(T, T) int) (T, bool) {
+	var result T
+	found := false
+	q.Iterate(func(item T) bool {
+		if !found || compare(item, result) > 0 {
+			result = item
+			found = true
+		}
+		return true
+	})
+	return result, found
+}
+
+// MinWith returns the minimum element according to compare and a boolean
+// reporting whether the collection was non-empty. compare follows the same
+// convention as cmp.Compare: a negative result means the first value is less
+// than the second. If multiple elements compare equal, MinWith returns the
+// first one.
+func (q Query[T]) MinWith(compare func(T, T) int) (T, bool) {
+	var result T
+	found := false
+	q.Iterate(func(item T) bool {
+		if !found || compare(item, result) < 0 {
+			result = item
+			found = true
+		}
+		return true
+	})
+	return result, found
+}
+
 // MaxBy returns the element of a collection with the maximum key, where the
 // key is obtained by invoking the selector function on each element, and a
 // boolean reporting whether the collection was non-empty.
@@ -251,4 +287,42 @@ func (q Query[T]) MinBy[TKey cmp.Ordered](selector func(T) TKey) (T, bool) {
 		return true
 	})
 	return r, found
+}
+
+// MaxByWith returns the element with the maximum selected key according to
+// compare and a boolean reporting whether the collection was non-empty. It
+// returns the first element when multiple keys compare equal.
+func (q Query[T]) MaxByWith[TKey any](selector func(T) TKey,
+	compare func(TKey, TKey) int) (T, bool) {
+	var result T
+	var resultKey TKey
+	found := false
+	q.Iterate(func(item T) bool {
+		key := selector(item)
+		if !found || compare(key, resultKey) > 0 {
+			result, resultKey = item, key
+			found = true
+		}
+		return true
+	})
+	return result, found
+}
+
+// MinByWith returns the element with the minimum selected key according to
+// compare and a boolean reporting whether the collection was non-empty. It
+// returns the first element when multiple keys compare equal.
+func (q Query[T]) MinByWith[TKey any](selector func(T) TKey,
+	compare func(TKey, TKey) int) (T, bool) {
+	var result T
+	var resultKey TKey
+	found := false
+	q.Iterate(func(item T) bool {
+		key := selector(item)
+		if !found || compare(key, resultKey) < 0 {
+			result, resultKey = item, key
+			found = true
+		}
+		return true
+	})
+	return result, found
 }

--- a/numeric_test.go
+++ b/numeric_test.go
@@ -1,7 +1,9 @@
 package linq
 
 import (
+	"cmp"
 	"math"
+	"slices"
 	"testing"
 )
 
@@ -163,5 +165,60 @@ func TestMinBy(t *testing.T) {
 		return len(s)
 	}); ok || r != "" {
 		t.Errorf("MinBy()=%v,%v expected \"\",false", r, ok)
+	}
+}
+
+func TestMinMaxWith(t *testing.T) {
+	type score struct {
+		name  string
+		value int
+	}
+	input := []score{{"first", 10}, {"low", 2}, {"second", 10}}
+	compare := func(a, b score) int { return cmp.Compare(a.value, b.value) }
+
+	if got, ok := FromSlice(input).MaxWith(compare); !ok || got != input[0] {
+		t.Errorf("MaxWith()=%v,%v expected %v,true", got, ok, input[0])
+	}
+	if got, ok := FromSlice(input).MinWith(compare); !ok || got != input[1] {
+		t.Errorf("MinWith()=%v,%v expected %v,true", got, ok, input[1])
+	}
+	if got, ok := FromSlice([]score{}).MaxWith(compare); ok || got != (score{}) {
+		t.Errorf("empty MaxWith()=%v,%v expected zero,false", got, ok)
+	}
+	if got, ok := FromSlice([]score{}).MinWith(compare); ok || got != (score{}) {
+		t.Errorf("empty MinWith()=%v,%v expected zero,false", got, ok)
+	}
+}
+
+func TestMinMaxByWith(t *testing.T) {
+	type item struct {
+		name string
+		key  []int
+	}
+	input := []item{
+		{"first max", []int{2}},
+		{"min", []int{1}},
+		{"second max", []int{2}},
+	}
+
+	selectorCalls := 0
+	selector := func(item item) []int {
+		selectorCalls++
+		return item.key
+	}
+
+	if got, ok := FromSlice(input).MaxByWith(selector, slices.Compare); !ok || got.name != "first max" {
+		t.Errorf("MaxByWith()=%v,%v expected first max,true", got, ok)
+	}
+	if selectorCalls != len(input) {
+		t.Errorf("MaxByWith selector called %d times expected %d", selectorCalls, len(input))
+	}
+
+	selectorCalls = 0
+	if got, ok := FromSlice(input).MinByWith(selector, slices.Compare); !ok || got.name != "min" {
+		t.Errorf("MinByWith()=%v,%v expected min,true", got, ok)
+	}
+	if selectorCalls != len(input) {
+		t.Errorf("MinByWith selector called %d times expected %d", selectorCalls, len(input))
 	}
 }

--- a/orderby.go
+++ b/orderby.go
@@ -30,6 +30,9 @@ func descending[T any, TKey cmp.Ordered](selector func(T) TKey) func(a, b T) int
 // sortedIterate returns a sequence that collects the query into a slice and
 // sorts it with the given comparison functions, applied in order until one of
 // them reports a difference.
+//
+// The sort is stable so elements that compare equal retain their input order,
+// matching .NET LINQ.
 func (q Query[T]) sortedIterate(compares []func(a, b T) int) iter.Seq[T] {
 	compare := compares[0]
 	if len(compares) > 1 {
@@ -46,7 +49,7 @@ func (q Query[T]) sortedIterate(compares []func(a, b T) int) iter.Seq[T] {
 	return func(yield func(T) bool) {
 		items := q.collect()
 
-		slices.SortFunc(items, compare)
+		slices.SortStableFunc(items, compare)
 
 		for _, item := range items {
 			if !yield(item) {
@@ -56,22 +59,38 @@ func (q Query[T]) sortedIterate(compares []func(a, b T) int) iter.Seq[T] {
 	}
 }
 
+// newOrderedQuery builds what every ordering operator returns: the sorted
+// sequence, plus the unsorted original and the comparison chain that ThenBy
+// and ThenByDescending extend.
+func newOrderedQuery[T any](original Query[T], compares []func(a, b T) int) OrderedQuery[T] {
+	return OrderedQuery[T]{
+		compares: compares,
+		original: original,
+		Query: Query[T]{
+			Iterate: original.sortedIterate(compares),
+			size:    original.size,
+		},
+	}
+}
+
+// Order sorts the elements of a collection in ascending order.
+func Order[T cmp.Ordered](q Query[T]) OrderedQuery[T] {
+	return q.OrderBy(func(item T) T { return item })
+}
+
 // OrderBy sorts the elements of a collection in ascending order. Elements are
 // sorted according to a key.
 //
+// The sort is stable: elements with equal keys retain their original relative
+// order, matching .NET LINQ. OrderByDescending, ThenBy and ThenByDescending
+// share this guarantee.
+//
 // OrderBy is a generic method: the key type TKey is inferred from the selector
 // function and must be an ordered type (cmp.Ordered). To sort by a custom
-// comparison instead, use the Sort method.
+// comparison instead, use OrderWith, or Sort when stability and chaining are
+// not needed.
 func (q Query[T]) OrderBy[TKey cmp.Ordered](selector func(T) TKey) OrderedQuery[T] {
-	compares := []func(a, b T) int{ascending(selector)}
-	return OrderedQuery[T]{
-		compares: compares,
-		original: q,
-		Query: Query[T]{
-			Iterate: q.sortedIterate(compares),
-			size:    q.size,
-		},
-	}
+	return newOrderedQuery(q, []func(a, b T) int{ascending(selector)})
 }
 
 // OrderByDescending sorts the elements of a collection in descending order.
@@ -80,45 +99,44 @@ func (q Query[T]) OrderBy[TKey cmp.Ordered](selector func(T) TKey) OrderedQuery[
 // OrderByDescending is a generic method: the key type TKey is inferred from the
 // selector function and must be an ordered type (cmp.Ordered).
 func (q Query[T]) OrderByDescending[TKey cmp.Ordered](selector func(T) TKey) OrderedQuery[T] {
-	compares := []func(a, b T) int{descending(selector)}
-	return OrderedQuery[T]{
-		compares: compares,
-		original: q,
-		Query: Query[T]{
-			Iterate: q.sortedIterate(compares),
-			size:    q.size,
-		},
-	}
+	return newOrderedQuery(q, []func(a, b T) int{descending(selector)})
+}
+
+// OrderDescending sorts the elements of a collection in descending order.
+func OrderDescending[T cmp.Ordered](q Query[T]) OrderedQuery[T] {
+	return q.OrderByDescending(func(item T) T { return item })
+}
+
+// OrderWith sorts the elements of a collection with the provided comparison
+// function. compare follows the same convention as cmp.Compare: a negative
+// result means the first value is less than the second.
+//
+// Like OrderBy the sort is stable, and the result is an OrderedQuery that
+// ThenBy and ThenByDescending can refine further. Unlike OrderBy it places no
+// constraint on the element type. Sort accepts arbitrary comparison logic too,
+// but is unstable and does not compose with ThenBy.
+func (q Query[T]) OrderWith(compare func(T, T) int) OrderedQuery[T] {
+	return newOrderedQuery(q, []func(a, b T) int{compare})
+}
+
+// OrderDescendingWith sorts the elements of a collection in the reverse of the
+// order given by compare, which follows the same convention as cmp.Compare.
+func (q Query[T]) OrderDescendingWith(compare func(T, T) int) OrderedQuery[T] {
+	return q.OrderWith(func(a, b T) int { return compare(b, a) })
 }
 
 // ThenBy performs a subsequent ordering of the elements in a collection in
 // ascending order. This method enables you to specify multiple sort criteria by
 // applying any number of ThenBy or ThenByDescending methods.
 func (oq OrderedQuery[T]) ThenBy[TKey cmp.Ordered](selector func(T) TKey) OrderedQuery[T] {
-	compares := append(slices.Clip(oq.compares), ascending(selector))
-	return OrderedQuery[T]{
-		compares: compares,
-		original: oq.original,
-		Query: Query[T]{
-			Iterate: oq.original.sortedIterate(compares),
-			size:    oq.original.size,
-		},
-	}
+	return newOrderedQuery(oq.original, append(slices.Clip(oq.compares), ascending(selector)))
 }
 
 // ThenByDescending performs a subsequent ordering of the elements in a
 // collection in descending order. This method enables you to specify multiple
 // sort criteria by applying any number of ThenBy or ThenByDescending methods.
 func (oq OrderedQuery[T]) ThenByDescending[TKey cmp.Ordered](selector func(T) TKey) OrderedQuery[T] {
-	compares := append(slices.Clip(oq.compares), descending(selector))
-	return OrderedQuery[T]{
-		compares: compares,
-		original: oq.original,
-		Query: Query[T]{
-			Iterate: oq.original.sortedIterate(compares),
-			size:    oq.original.size,
-		},
-	}
+	return newOrderedQuery(oq.original, append(slices.Clip(oq.compares), descending(selector)))
 }
 
 // sorter adapts a less function to sort.Interface so that sorting calls the
@@ -139,6 +157,9 @@ func (s sorter[T]) Less(i, j int) bool { return s.less(s.items[i], s.items[j]) }
 // Unlike OrderBy, Sort does not require the sort key to be an ordered type,
 // so it can be used with arbitrary comparison logic. The less function is
 // invoked once per element comparison.
+//
+// Also unlike OrderBy, Sort is not stable: elements that compare equal may be
+// reordered.
 func (q Query[T]) Sort(less func(i, j T) bool) Query[T] {
 	return Query[T]{
 		Iterate: func(yield func(T) bool) {

--- a/orderby_test.go
+++ b/orderby_test.go
@@ -140,8 +140,6 @@ func TestOrderingIsStable(t *testing.T) {
 }
 
 func TestOrderWith(t *testing.T) {
-	// Input order puts "erin" before "dave" so that stable length ordering and
-	// alphabetical ordering disagree, making the ThenBy case below meaningful.
 	names := []string{"erin", "al", "dave", "bo", "cy", "frank"}
 	byLen := func(a, b string) int { return cmp.Compare(len(a), len(b)) }
 
@@ -156,8 +154,7 @@ func TestOrderWith(t *testing.T) {
 		t.Errorf("OrderDescendingWith(byLen)=%v expected %v", got.ToSlice(), wantDesc)
 	}
 
-	// The point of returning OrderedQuery: ThenBy refines the comparison, so
-	// the equal-length pair flips from input order to alphabetical.
+	// ThenBy orders equal-length names alphabetically instead of preserving input order.
 	wantThen := []string{"al", "bo", "cy", "dave", "erin", "frank"}
 	if got := q.OrderWith(byLen).ThenBy(func(s string) string { return s }); !testQueryIteration(got.Query, wantThen) {
 		t.Errorf("OrderWith(byLen).ThenBy(self)=%v expected %v", got.ToSlice(), wantThen)

--- a/orderby_test.go
+++ b/orderby_test.go
@@ -1,6 +1,7 @@
 package linq
 
 import (
+	"cmp"
 	"iter"
 	"testing"
 )
@@ -71,6 +72,95 @@ func TestOrderByDescending(t *testing.T) {
 		}
 
 		j--
+	}
+}
+
+func TestOrder(t *testing.T) {
+	type score int
+	input := []score{3, 1, 2, 1}
+
+	if q := Order(FromSlice(input)); !testQueryIteration(q.Query, []score{1, 1, 2, 3}) {
+		t.Errorf("Order()=%v expected [1 1 2 3]", q.ToSlice())
+	}
+	if q := OrderDescending(FromSlice(input)); !testQueryIteration(q.Query, []score{3, 2, 1, 1}) {
+		t.Errorf("OrderDescending()=%v expected [3 2 1 1]", q.ToSlice())
+	}
+}
+
+func TestOrderingIsStable(t *testing.T) {
+	type entry struct {
+		primary   int
+		secondary int
+		position  int
+	}
+
+	input := make([]entry, 64)
+	for i := range input {
+		input[i] = entry{primary: i % 4, secondary: (i / 4) % 2, position: i}
+	}
+
+	assertStable := func(name string, q Query[entry], key func(entry) int) {
+		t.Helper()
+		last := make(map[int]int)
+		for _, e := range q.ToSlice() {
+			k := key(e)
+			if previous, ok := last[k]; ok && e.position < previous {
+				t.Errorf("%s reordered equal keys: position %d after %d", name, e.position, previous)
+			}
+			last[k] = e.position
+		}
+	}
+
+	q := FromSlice(input)
+	assertStable("OrderBy", q.OrderBy(func(e entry) int {
+		return e.primary
+	}).Query, func(e entry) int {
+		return e.primary
+	})
+	assertStable("OrderByDescending", q.OrderByDescending(func(e entry) int {
+		return e.primary
+	}).Query, func(e entry) int {
+		return e.primary
+	})
+	assertStable("ThenBy", q.OrderBy(func(e entry) int {
+		return e.primary
+	}).ThenBy(func(e entry) int {
+		return e.secondary
+	}).Query, func(e entry) int {
+		return e.primary*10 + e.secondary
+	})
+
+	byPrimary := func(a, b entry) int { return cmp.Compare(a.primary, b.primary) }
+	assertStable("OrderWith", q.OrderWith(byPrimary).Query, func(e entry) int {
+		return e.primary
+	})
+	assertStable("OrderDescendingWith", q.OrderDescendingWith(byPrimary).Query, func(e entry) int {
+		return e.primary
+	})
+}
+
+func TestOrderWith(t *testing.T) {
+	// Input order puts "erin" before "dave" so that stable length ordering and
+	// alphabetical ordering disagree, making the ThenBy case below meaningful.
+	names := []string{"erin", "al", "dave", "bo", "cy", "frank"}
+	byLen := func(a, b string) int { return cmp.Compare(len(a), len(b)) }
+
+	q := FromSlice(names)
+	want := []string{"al", "bo", "cy", "erin", "dave", "frank"}
+	if got := q.OrderWith(byLen); !testQueryIteration(got.Query, want) {
+		t.Errorf("OrderWith(byLen)=%v expected %v", got.ToSlice(), want)
+	}
+
+	wantDesc := []string{"frank", "erin", "dave", "al", "bo", "cy"}
+	if got := q.OrderDescendingWith(byLen); !testQueryIteration(got.Query, wantDesc) {
+		t.Errorf("OrderDescendingWith(byLen)=%v expected %v", got.ToSlice(), wantDesc)
+	}
+
+	// The point of returning OrderedQuery: ThenBy refines the comparison, so
+	// the equal-length pair flips from input order to alphabetical.
+	wantThen := []string{"al", "bo", "cy", "dave", "erin", "frank"}
+	if got := q.OrderWith(byLen).ThenBy(func(s string) string { return s }); !testQueryIteration(got.Query, wantThen) {
+		t.Errorf("OrderWith(byLen).ThenBy(self)=%v expected %v", got.ToSlice(), wantThen)
 	}
 }
 

--- a/result.go
+++ b/result.go
@@ -301,6 +301,21 @@ func (q Query[T]) ToMapBy[TKey comparable, TValue any](
 	return result
 }
 
+// ToHashSetBy iterates over a collection and returns the distinct keys
+// obtained by invoking the selector function on each element, as a map-backed
+// set. Unlike ToHashSet it places no constraint on the element type.
+//
+// ToHashSetBy is a generic method: the key type TKey is inferred from the
+// selector function. The key type TKey must be comparable.
+func (q Query[T]) ToHashSetBy[TKey comparable](selector func(T) TKey) map[TKey]struct{} {
+	result := make(map[TKey]struct{})
+	q.Iterate(func(item T) bool {
+		result[selector(item)] = struct{}{}
+		return true
+	})
+	return result
+}
+
 // ToSlice iterates over a collection and returns the results as a slice.
 // When the query's element count is known up front (e.g. a slice source
 // transformed only by length-preserving operators), the result slice is

--- a/result.go
+++ b/result.go
@@ -273,6 +273,17 @@ func ToMap[TKey comparable, TValue any](q Query[KeyValue[TKey, TValue]]) map[TKe
 	return result
 }
 
+// ToHashSet iterates over a collection and returns its distinct elements as a
+// map-backed set.
+func ToHashSet[T comparable](q Query[T]) map[T]struct{} {
+	result := make(map[T]struct{})
+	q.Iterate(func(item T) bool {
+		result[item] = struct{}{}
+		return true
+	})
+	return result
+}
+
 // ToMapBy iterates over a collection and returns a map populated with
 // elements. Functions keySelector and valueSelector are executed for each
 // element of the collection to generate the key and value for the map.

--- a/result_test.go
+++ b/result_test.go
@@ -337,6 +337,25 @@ func TestToMapBy_TypeChanging(t *testing.T) {
 	}
 }
 
+func TestToHashSetBy(t *testing.T) {
+	// A slice element is not comparable, so ToHashSet cannot take this query
+	// at all; only the selected key can key the set.
+	type record struct {
+		name string
+		tags []string
+	}
+
+	input := []record{{"a", []string{"x"}}, {"b", nil}, {"a", []string{"y"}}}
+	want := map[string]struct{}{"a": {}, "b": {}}
+	got := FromSlice(input).ToHashSetBy(func(r record) string { return r.name })
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ToHashSetBy(%v)=%v expected %v", input, got, want)
+	}
+	if got := Empty[record]().ToHashSetBy(func(r record) string { return r.name }); got == nil || len(got) != 0 {
+		t.Errorf("ToHashSetBy(empty)=%v expected initialized empty map", got)
+	}
+}
+
 func TestToSlice(t *testing.T) {
 	input := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 

--- a/result_test.go
+++ b/result_test.go
@@ -289,6 +289,22 @@ func TestToMap(t *testing.T) {
 	}
 }
 
+func TestToHashSet(t *testing.T) {
+	type key struct {
+		id   int
+		name string
+	}
+
+	input := []key{{1, "one"}, {2, "two"}, {1, "one"}}
+	want := map[key]struct{}{{1, "one"}: {}, {2, "two"}: {}}
+	if got := ToHashSet(FromSlice(input)); !reflect.DeepEqual(got, want) {
+		t.Errorf("ToHashSet(%v)=%v expected %v", input, got, want)
+	}
+	if got := ToHashSet(Empty[key]()); got == nil || len(got) != 0 {
+		t.Errorf("ToHashSet(Empty[key]())=%v expected initialized empty map", got)
+	}
+}
+
 func TestToMapBy(t *testing.T) {
 	input := make(map[int]bool)
 	input[1] = true

--- a/shuffle.go
+++ b/shuffle.go
@@ -1,0 +1,25 @@
+package linq
+
+import "math/rand/v2"
+
+// Shuffle returns the elements of a collection in randomized order. It uses a
+// non-cryptographically-secure random number generator and reshuffles on every
+// iteration.
+func (q Query[T]) Shuffle() Query[T] {
+	return Query[T]{
+		Iterate: func(yield func(T) bool) {
+			items := q.collect()
+			for i := len(items) - 1; i > 0; i-- {
+				j := rand.IntN(i + 1)
+				items[i], items[j] = items[j], items[i]
+			}
+
+			for _, item := range items {
+				if !yield(item) {
+					return
+				}
+			}
+		},
+		size: q.size,
+	}
+}

--- a/shuffle_test.go
+++ b/shuffle_test.go
@@ -20,10 +20,8 @@ func TestShuffle(t *testing.T) {
 			t.Errorf("Shuffle()=%v expected permutation of %v", orders[i], original)
 		}
 	}
-	// A Shuffle that does nothing, and one that shuffles once and caches the
-	// result, both hold the order fixed across iterations. Two distinct orders
-	// rule out both. With 360 distinguishable permutations of the source, a
-	// false failure here runs at (1/360)^19.
+	// Repeated identical output catches both a no-op and a cached shuffle;
+	// the false-failure probability is (1/360)^19.
 	if !slices.ContainsFunc(orders, func(o []int) bool { return !slices.Equal(o, orders[0]) }) {
 		t.Errorf("Shuffle yielded %v on all 20 iterations; expected the order to vary", orders[0])
 	}

--- a/shuffle_test.go
+++ b/shuffle_test.go
@@ -1,0 +1,78 @@
+package linq
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestShuffle(t *testing.T) {
+	source := []int{1, 1, 2, 3, 5, 8}
+	original := slices.Clone(source)
+	q := FromSlice(source).Shuffle()
+
+	orders := make([][]int, 20)
+	for i := range orders {
+		orders[i] = q.ToSlice()
+
+		sorted := slices.Clone(orders[i])
+		slices.Sort(sorted)
+		if !slices.Equal(sorted, original) {
+			t.Errorf("Shuffle()=%v expected permutation of %v", orders[i], original)
+		}
+	}
+	// A Shuffle that does nothing, and one that shuffles once and caches the
+	// result, both hold the order fixed across iterations. Two distinct orders
+	// rule out both. With 360 distinguishable permutations of the source, a
+	// false failure here runs at (1/360)^19.
+	if !slices.ContainsFunc(orders, func(o []int) bool { return !slices.Equal(o, orders[0]) }) {
+		t.Errorf("Shuffle yielded %v on all 20 iterations; expected the order to vary", orders[0])
+	}
+	if !slices.Equal(source, original) {
+		t.Errorf("Shuffle modified source: got %v expected %v", source, original)
+	}
+	if got := FromSlice([]int{}).Shuffle().ToSlice(); got != nil {
+		t.Errorf("Shuffle(empty)=%v expected nil", got)
+	}
+	if got := FromSlice([]int{42}).Shuffle().ToSlice(); !slices.Equal(got, []int{42}) {
+		t.Errorf("Shuffle(single)=%v expected [42]", got)
+	}
+}
+
+func TestShuffleBuffersBeforeYielding(t *testing.T) {
+	pulled := 0
+	q := FromSlice([]int{1, 2, 3, 4}).Where(func(int) bool {
+		pulled++
+		return true
+	}).Shuffle()
+
+	q.Iterate(func(int) bool { return false })
+	if pulled != 4 {
+		t.Errorf("Shuffle pulled %d elements expected 4", pulled)
+	}
+}
+
+func TestShuffleTakeSamplesWholeSource(t *testing.T) {
+	pulled := 0
+	source := FromSeq(func(yield func(int) bool) {
+		for i := range 100 {
+			pulled++
+			if !yield(i) {
+				return
+			}
+		}
+	})
+
+	got := source.Shuffle().Take(5).ToSlice()
+	if pulled != 100 {
+		t.Errorf("Shuffle().Take(5) pulled %d elements expected 100", pulled)
+	}
+	if len(got) != 5 {
+		t.Fatalf("Shuffle().Take(5) returned %d elements expected 5", len(got))
+	}
+	slices.Sort(got)
+	for i, item := range got {
+		if item < 0 || item >= 100 || i > 0 && item == got[i-1] {
+			t.Fatalf("Shuffle().Take(5) returned invalid sample %v", got)
+		}
+	}
+}

--- a/size_test.go
+++ b/size_test.go
@@ -50,7 +50,8 @@ func TestDerivedSizeHints(t *testing.T) {
 	q := FromSlice(make([]int, 10))
 	checkSizeHint(t, "SkipLast", q.SkipLast(3), 7)
 	checkSizeHint(t, "TakeLast", q.TakeLast(3), 3)
-	checkSizeHint(t, "TakeRange", q.TakeRange(IndexFromEnd(7), IndexFromStart(8)), 5)
+	checkSizeHint(t, "TakeRange", q.TakeRange(PositionFromEnd(7), PositionFromStart(8)), 5)
+	checkSizeHint(t, "Index", Index(q), 10)
 	checkSizeHint(t, "Zip3", q.Zip3(Range(0, 8), Range(0, 6), func(a, b, c int) int {
 		return a + b + c
 	}), 6)

--- a/size_test.go
+++ b/size_test.go
@@ -3,8 +3,8 @@ package linq
 import "testing"
 
 // The size hint carried by Query is an invariant the compiler cannot check:
-// it may be propagated only by operators that emit exactly one element per
-// source element. These tests pin it in both directions.
+// it may be propagated only when an operator can derive its output count
+// exactly. These tests pin it in both directions.
 
 // TestSizeHint_ExactPreallocation catches an operator losing the hint: append
 // growth never lands on an arbitrary exact size (collecting 1000 elements by
@@ -37,4 +37,22 @@ func TestSizeHint_DroppedByFilters(t *testing.T) {
 	if cap(out) >= 100_000 {
 		t.Errorf("cap=%d: filtered query inherited the source's size hint", cap(out))
 	}
+}
+
+func checkSizeHint[T any](t *testing.T, name string, q Query[T], want int) {
+	t.Helper()
+	if got := q.size; got != want {
+		t.Errorf("%s size=%d expected %d", name, got, want)
+	}
+}
+
+func TestDerivedSizeHints(t *testing.T) {
+	q := FromSlice(make([]int, 10))
+	checkSizeHint(t, "SkipLast", q.SkipLast(3), 7)
+	checkSizeHint(t, "TakeLast", q.TakeLast(3), 3)
+	checkSizeHint(t, "TakeRange", q.TakeRange(IndexFromEnd(7), IndexFromStart(8)), 5)
+	checkSizeHint(t, "Zip3", q.Zip3(Range(0, 8), Range(0, 6), func(a, b, c int) int {
+		return a + b + c
+	}), 6)
+	checkSizeHint(t, "Chunk", Chunk(q, 3), 4)
 }

--- a/size_test.go
+++ b/size_test.go
@@ -93,3 +93,28 @@ func checkExactSizeHint[T any](t *testing.T, name string, q Query[T]) {
 		t.Errorf("Sequence(%s) size=%d expected %d", name, got, want)
 	}
 }
+
+// TestPresizeIsBoundedBySource catches a buffer preallocated from a caller's
+// count rather than from what the source can supply. MaxInt is a capacity no
+// make can serve, so a reserving operator panics with "cap out of range"
+// instead of quietly wasting memory the way a merely large count would.
+func TestPresizeIsBoundedBySource(t *testing.T) {
+	// Where drops the size hint, leaving the length unknown.
+	three := func() Query[int] {
+		return FromSlice([]int{1, 2, 3}).Where(func(int) bool { return true })
+	}
+	all := []int{1, 2, 3}
+
+	if q := three().SkipLast(math.MaxInt); !testQueryIteration(q, nil) {
+		t.Errorf("SkipLast(MaxInt)=%v expected nothing", q.ToSlice())
+	}
+	if q := three().TakeLast(math.MaxInt); !testQueryIteration(q, all) {
+		t.Errorf("TakeLast(MaxInt)=%v expected %v", q.ToSlice(), all)
+	}
+	if q := three().TakeRange(PositionFromEnd(math.MaxInt), PositionFromEnd(1)); !testQueryIteration(q, []int{1, 2}) {
+		t.Errorf("TakeRange(FromEnd(MaxInt), FromEnd(1))=%v expected [1 2]", q.ToSlice())
+	}
+	if _, ok := three().ElementAt(PositionFromEnd(math.MaxInt)); ok {
+		t.Error("ElementAt(FromEnd(MaxInt)) reported a hit")
+	}
+}

--- a/size_test.go
+++ b/size_test.go
@@ -53,13 +53,14 @@ func TestDerivedSizeHints(t *testing.T) {
 	q := FromSlice(make([]int, 10))
 	checkSizeHint(t, "SkipLast", q.SkipLast(3), 7)
 	checkSizeHint(t, "TakeLast", q.TakeLast(3), 3)
-	checkSizeHint(t, "TakeRange", q.TakeRange(PositionFromEnd(7), PositionFromStart(8)), 5)
+	checkSizeHint(t, "TakeRange", q.TakeRange(FromEnd(7), FromStart(8)), 5)
 	checkSizeHint(t, "Index", Index(q), 10)
 	checkSizeHint(t, "Shuffle", q.Shuffle(), 10)
 	checkSizeHint(t, "Zip3", q.Zip3(Range(0, 8), Range(0, 6), func(a, b, c int) int {
 		return a + b + c
 	}), 6)
 	checkSizeHint(t, "Chunk", Chunk(q, 3), 4)
+	checkSizeHint(t, "ChunkBy", q.ChunkBy(3, func(c []int) int { return len(c) }), 4)
 }
 
 // TestSequenceSizeHint pins Sequence's hint against the sequence it describes
@@ -111,10 +112,10 @@ func TestPresizeIsBoundedBySource(t *testing.T) {
 	if q := three().TakeLast(math.MaxInt); !testQueryIteration(q, all) {
 		t.Errorf("TakeLast(MaxInt)=%v expected %v", q.ToSlice(), all)
 	}
-	if q := three().TakeRange(PositionFromEnd(math.MaxInt), PositionFromEnd(1)); !testQueryIteration(q, []int{1, 2}) {
+	if q := three().TakeRange(FromEnd(math.MaxInt), FromEnd(1)); !testQueryIteration(q, []int{1, 2}) {
 		t.Errorf("TakeRange(FromEnd(MaxInt), FromEnd(1))=%v expected [1 2]", q.ToSlice())
 	}
-	if _, ok := three().ElementAt(PositionFromEnd(math.MaxInt)); ok {
+	if _, ok := three().ElementAt(FromEnd(math.MaxInt)); ok {
 		t.Error("ElementAt(FromEnd(MaxInt)) reported a hit")
 	}
 }

--- a/size_test.go
+++ b/size_test.go
@@ -1,6 +1,9 @@
 package linq
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 // The size hint carried by Query is an invariant the compiler cannot check:
 // it may be propagated only when an operator can derive its output count
@@ -52,8 +55,41 @@ func TestDerivedSizeHints(t *testing.T) {
 	checkSizeHint(t, "TakeLast", q.TakeLast(3), 3)
 	checkSizeHint(t, "TakeRange", q.TakeRange(PositionFromEnd(7), PositionFromStart(8)), 5)
 	checkSizeHint(t, "Index", Index(q), 10)
+	checkSizeHint(t, "Shuffle", q.Shuffle(), 10)
 	checkSizeHint(t, "Zip3", q.Zip3(Range(0, 8), Range(0, 6), func(a, b, c int) int {
 		return a + b + c
 	}), 6)
 	checkSizeHint(t, "Chunk", Chunk(q, 3), 4)
+}
+
+// TestSequenceSizeHint pins Sequence's hint against the sequence it describes
+// rather than against literals, so the count stays honest for the cases that
+// stop early on overflow. Floats get no hint: an accumulated step lands where
+// arithmetic on the bounds cannot predict.
+func TestSequenceSizeHint(t *testing.T) {
+	checkExactSizeHint(t, "increasing", Sequence(1, 10, 1))
+	checkExactSizeHint(t, "bound not reached", Sequence(0, 5, 2))
+	checkExactSizeHint(t, "decreasing", Sequence(10, 1, -3))
+	checkExactSizeHint(t, "equal bounds", Sequence(3, 3, 1))
+	checkExactSizeHint(t, "int8 stopping on overflow", Sequence(int8(126), int8(127), int8(2)))
+	checkExactSizeHint(t, "int8 full span", Sequence(int8(-128), int8(127), int8(1)))
+	checkExactSizeHint(t, "uint8 stopping on overflow", Sequence(uint8(254), uint8(255), uint8(2)))
+	checkExactSizeHint(t, "most negative step", Sequence(int8(127), int8(-128), int8(-128)))
+
+	checkSizeHint(t, "Sequence(float64)", Sequence(0.5, 1.25, 0.25), 0)
+
+	// Counts too wide to be a capacity, checked by hint alone: collecting
+	// either sequence would be the OOM the missing hint is there to avoid.
+	// The second one carries the count past uint64 and wraps it.
+	checkSizeHint(t, "Sequence(count past int)",
+		Sequence(int64(0), int64(math.MaxInt64), int64(1)), 0)
+	checkSizeHint(t, "Sequence(count past uint64)",
+		Sequence(int64(math.MinInt64), int64(math.MaxInt64), int64(1)), 0)
+}
+
+func checkExactSizeHint[T any](t *testing.T, name string, q Query[T]) {
+	t.Helper()
+	if got, want := q.size, len(q.ToSlice()); got != want {
+		t.Errorf("Sequence(%s) size=%d expected %d", name, got, want)
+	}
 }

--- a/skip.go
+++ b/skip.go
@@ -17,6 +17,40 @@ func (q Query[T]) Skip(count int) Query[T] {
 	}
 }
 
+// SkipLast returns all elements of a collection except its last count
+// elements. It buffers at most count elements and otherwise streams results.
+func (q Query[T]) SkipLast(count int) Query[T] {
+	if count <= 0 {
+		return q
+	}
+
+	return Query[T]{
+		Iterate: func(yield func(T) bool) {
+			capacity := q.size
+			if capacity == 0 || capacity > count {
+				capacity = count
+			}
+			items := make([]T, 0, capacity)
+			head := 0
+			q.Iterate(func(item T) bool {
+				if len(items) < count {
+					items = append(items, item)
+					return true
+				}
+
+				result := items[head]
+				items[head] = item
+				head++
+				if head == len(items) {
+					head = 0
+				}
+				return yield(result)
+			})
+		},
+		size: max(q.size-count, 0),
+	}
+}
+
 // SkipWhile bypasses elements in a collection as long as a specified condition
 // is true and then returns the remaining elements.
 //

--- a/skip.go
+++ b/skip.go
@@ -26,11 +26,7 @@ func (q Query[T]) SkipLast(count int) Query[T] {
 
 	return Query[T]{
 		Iterate: func(yield func(T) bool) {
-			capacity := q.size
-			if capacity == 0 || capacity > count {
-				capacity = count
-			}
-			items := make([]T, 0, capacity)
+			items := make([]T, 0, min(count, q.size))
 			head := 0
 			q.Iterate(func(item T) bool {
 				if len(items) < count {

--- a/skip_test.go
+++ b/skip_test.go
@@ -26,6 +26,48 @@ func TestSkip(t *testing.T) {
 	}
 }
 
+func TestSkipLast(t *testing.T) {
+	input := []int{1, 2, 3, 4, 5}
+	tests := []struct {
+		count int
+		want  []int
+	}{
+		{-1, []int{1, 2, 3, 4, 5}},
+		{0, []int{1, 2, 3, 4, 5}},
+		{1, []int{1, 2, 3, 4}},
+		{3, []int{1, 2}},
+		{5, nil},
+		{10, nil},
+	}
+
+	for _, test := range tests {
+		if q := FromSlice(input).SkipLast(test.count); !testQueryIteration(q, test.want) {
+			t.Errorf("SkipLast(%d)=%v expected %v", test.count, toSlice(q), test.want)
+		}
+	}
+}
+
+func TestSkipLastStopsPullingAfterConsumerStops(t *testing.T) {
+	pulled := 0
+	q := FromSlice([]int{1, 2, 3, 4, 5}).Where(func(int) bool {
+		pulled++
+		return true
+	}).SkipLast(2)
+
+	var got []int
+	q.Iterate(func(item int) bool {
+		got = append(got, item)
+		return false
+	})
+
+	if len(got) != 1 || got[0] != 1 {
+		t.Errorf("SkipLast early exit yielded %v expected [1]", got)
+	}
+	if pulled != 3 {
+		t.Errorf("source pulled %d elements expected 3", pulled)
+	}
+}
+
 func TestSkipWhile(t *testing.T) {
 	tests := []struct {
 		input     Query[int]

--- a/take.go
+++ b/take.go
@@ -32,11 +32,7 @@ func lastItems[T any](q Query[T], count int) ([]T, int) {
 		return nil, 0
 	}
 
-	capacity := q.size
-	if capacity == 0 || capacity > count {
-		capacity = count
-	}
-	items := make([]T, 0, capacity)
+	items := make([]T, 0, min(count, q.size))
 	head := 0
 	total := 0
 	q.Iterate(func(item T) bool {

--- a/take.go
+++ b/take.go
@@ -88,7 +88,7 @@ func (q Query[T]) TakeLast(count int) Query[T] {
 // (exclusive). Out-of-range bounds are clipped; a reversed range is empty. A
 // start counted from the end consumes the entire source before yielding its
 // first element.
-func (q Query[T]) TakeRange(start, end Index) Query[T] {
+func (q Query[T]) TakeRange(start, end Position) Query[T] {
 	resultSize := max(end.offset(q.size)-start.offset(q.size), 0)
 
 	if !start.fromEnd {

--- a/take.go
+++ b/take.go
@@ -7,7 +7,7 @@ import "slices"
 // been yielded.
 func (q Query[T]) Take(count int) Query[T] {
 	if count <= 0 {
-		return emptyQuery[T]()
+		return Empty[T]()
 	}
 
 	return Query[T]{
@@ -68,7 +68,7 @@ func lastItems[T any](q Query[T], count int) ([]T, int) {
 // order. It consumes the source before yielding its first element.
 func (q Query[T]) TakeLast(count int) Query[T] {
 	if count <= 0 {
-		return emptyQuery[T]()
+		return Empty[T]()
 	}
 
 	return Query[T]{
@@ -93,7 +93,7 @@ func (q Query[T]) TakeRange(start, end Position) Query[T] {
 
 	if !start.fromEnd {
 		if !end.fromEnd && start.value >= end.value {
-			return emptyQuery[T]()
+			return Empty[T]()
 		}
 
 		result := q.Skip(start.value)
@@ -109,7 +109,7 @@ func (q Query[T]) TakeRange(start, end Position) Query[T] {
 	if start.value == 0 ||
 		(end.fromEnd && end.value >= start.value) ||
 		(!end.fromEnd && end.value == 0) {
-		return emptyQuery[T]()
+		return Empty[T]()
 	}
 
 	return Query[T]{

--- a/take.go
+++ b/take.go
@@ -1,11 +1,13 @@
 package linq
 
+import "slices"
+
 // Take returns a specified number of contiguous elements from the start of a
 // collection. It stops pulling from the source as soon as count elements have
 // been yielded.
 func (q Query[T]) Take(count int) Query[T] {
 	if count <= 0 {
-		return Query[T]{Iterate: func(func(T) bool) {}}
+		return emptyQuery[T]()
 	}
 
 	return Query[T]{
@@ -19,6 +21,109 @@ func (q Query[T]) Take(count int) Query[T] {
 				return n > 0
 			})
 		},
+	}
+}
+
+// lastItems consumes q and returns its last count elements in their original
+// order together with the total number of elements consumed. Its storage is
+// bounded by count.
+func lastItems[T any](q Query[T], count int) ([]T, int) {
+	if count <= 0 {
+		return nil, 0
+	}
+
+	capacity := q.size
+	if capacity == 0 || capacity > count {
+		capacity = count
+	}
+	items := make([]T, 0, capacity)
+	head := 0
+	total := 0
+	q.Iterate(func(item T) bool {
+		total++
+		if len(items) < count {
+			items = append(items, item)
+			return true
+		}
+
+		items[head] = item
+		head++
+		if head == len(items) {
+			head = 0
+		}
+		return true
+	})
+
+	if head == 0 {
+		return items, total
+	}
+
+	slices.Reverse(items[:head])
+	slices.Reverse(items[head:])
+	slices.Reverse(items)
+	return items, total
+}
+
+// TakeLast returns the last count elements of a collection in their original
+// order. It consumes the source before yielding its first element.
+func (q Query[T]) TakeLast(count int) Query[T] {
+	if count <= 0 {
+		return emptyQuery[T]()
+	}
+
+	return Query[T]{
+		Iterate: func(yield func(T) bool) {
+			items, _ := lastItems(q, count)
+			for _, item := range items {
+				if !yield(item) {
+					return
+				}
+			}
+		},
+		size: min(count, q.size),
+	}
+}
+
+// TakeRange returns the contiguous elements between start (inclusive) and end
+// (exclusive). Out-of-range bounds are clipped; a reversed range is empty. A
+// start counted from the end consumes the entire source before yielding its
+// first element.
+func (q Query[T]) TakeRange(start, end Index) Query[T] {
+	resultSize := max(end.offset(q.size)-start.offset(q.size), 0)
+
+	if !start.fromEnd {
+		if !end.fromEnd && start.value >= end.value {
+			return emptyQuery[T]()
+		}
+
+		result := q.Skip(start.value)
+		if end.fromEnd {
+			result = result.SkipLast(end.value)
+		} else {
+			result = result.Take(end.value - start.value)
+		}
+		result.size = resultSize
+		return result
+	}
+
+	if start.value == 0 ||
+		(end.fromEnd && end.value >= start.value) ||
+		(!end.fromEnd && end.value == 0) {
+		return emptyQuery[T]()
+	}
+
+	return Query[T]{
+		Iterate: func(yield func(T) bool) {
+			items, total := lastItems(q, start.value)
+			length := max(end.offset(total)-start.offset(total), 0)
+
+			for _, item := range items[:length] {
+				if !yield(item) {
+					return
+				}
+			}
+		},
+		size: resultSize,
 	}
 }
 

--- a/take_test.go
+++ b/take_test.go
@@ -28,6 +28,100 @@ func TestTake(t *testing.T) {
 	}
 }
 
+func TestTakeLast(t *testing.T) {
+	input := []int{1, 2, 3, 4, 5}
+	tests := []struct {
+		count int
+		want  []int
+	}{
+		{-1, nil},
+		{0, nil},
+		{1, []int{5}},
+		{3, []int{3, 4, 5}},
+		{5, []int{1, 2, 3, 4, 5}},
+		{10, []int{1, 2, 3, 4, 5}},
+	}
+
+	for _, test := range tests {
+		if q := FromSlice(input).TakeLast(test.count); !testQueryIteration(q, test.want) {
+			t.Errorf("TakeLast(%d)=%v expected %v", test.count, toSlice(q), test.want)
+		}
+	}
+}
+
+func TestTakeLastConsumesSourceBeforeYielding(t *testing.T) {
+	pulled := 0
+	q := FromSlice([]int{1, 2, 3, 4}).Where(func(int) bool {
+		pulled++
+		return true
+	}).TakeLast(2)
+
+	var got []int
+	q.Iterate(func(item int) bool {
+		got = append(got, item)
+		return false
+	})
+
+	if !slices.Equal(got, []int{3}) {
+		t.Errorf("TakeLast early exit yielded %v expected [3]", got)
+	}
+	if pulled != 4 {
+		t.Errorf("source pulled %d elements expected 4", pulled)
+	}
+}
+
+func TestTakeRange(t *testing.T) {
+	input := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	tests := []struct {
+		start Index
+		end   Index
+		want  []int
+	}{
+		{IndexFromStart(2), IndexFromStart(7), []int{2, 3, 4, 5, 6}},
+		{IndexFromStart(2), IndexFromEnd(3), []int{2, 3, 4, 5, 6}},
+		{IndexFromEnd(7), IndexFromEnd(3), []int{3, 4, 5, 6}},
+		{IndexFromEnd(7), IndexFromStart(8), []int{3, 4, 5, 6, 7}},
+		{IndexFromStart(0), IndexFromEnd(0), input},
+		{IndexFromStart(20), IndexFromEnd(0), nil},
+		{IndexFromEnd(20), IndexFromEnd(0), input},
+		{IndexFromEnd(2), IndexFromEnd(5), nil},
+		{IndexFromStart(7), IndexFromStart(2), nil},
+		{IndexFromStart(2), IndexFromStart(20), []int{2, 3, 4, 5, 6, 7, 8, 9}},
+		{IndexFromStart(2), IndexFromEnd(20), nil},
+		{IndexFromEnd(20), IndexFromStart(3), []int{0, 1, 2}},
+	}
+
+	sources := []Query[int]{
+		FromSlice(input),
+		FromSeq(FromSlice(input).Iterate),
+	}
+	for _, source := range sources {
+		for _, test := range tests {
+			q := source.TakeRange(test.start, test.end)
+			if !testQueryIteration(q, test.want) {
+				t.Errorf("TakeRange(%v, %v)=%v expected %v",
+					test.start, test.end,
+					toSlice(q), test.want)
+			}
+		}
+	}
+}
+
+func TestTakeRangeFromStartStopsAtEnd(t *testing.T) {
+	pulled := 0
+	q := FromSlice([]int{0, 1, 2, 3, 4, 5}).Where(func(int) bool {
+		pulled++
+		return true
+	}).TakeRange(IndexFromStart(2), IndexFromStart(5))
+
+	if got := q.ToSlice(); !slices.Equal(got, []int{2, 3, 4}) {
+		t.Errorf("TakeRange(IndexFromStart(2), IndexFromStart(5))=%v expected [2 3 4]", got)
+	}
+	if pulled != 5 {
+		t.Errorf("source pulled %d elements expected 5", pulled)
+	}
+}
+
 // TestTakePullsExactlyCount verifies Take stops pulling from the source once
 // it has yielded count elements, rather than pulling one extra element just to
 // discard it. The Where predicate counts how many elements the source produced.

--- a/take_test.go
+++ b/take_test.go
@@ -73,22 +73,22 @@ func TestTakeLastConsumesSourceBeforeYielding(t *testing.T) {
 func TestTakeRange(t *testing.T) {
 	input := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 	tests := []struct {
-		start Index
-		end   Index
+		start Position
+		end   Position
 		want  []int
 	}{
-		{IndexFromStart(2), IndexFromStart(7), []int{2, 3, 4, 5, 6}},
-		{IndexFromStart(2), IndexFromEnd(3), []int{2, 3, 4, 5, 6}},
-		{IndexFromEnd(7), IndexFromEnd(3), []int{3, 4, 5, 6}},
-		{IndexFromEnd(7), IndexFromStart(8), []int{3, 4, 5, 6, 7}},
-		{IndexFromStart(0), IndexFromEnd(0), input},
-		{IndexFromStart(20), IndexFromEnd(0), nil},
-		{IndexFromEnd(20), IndexFromEnd(0), input},
-		{IndexFromEnd(2), IndexFromEnd(5), nil},
-		{IndexFromStart(7), IndexFromStart(2), nil},
-		{IndexFromStart(2), IndexFromStart(20), []int{2, 3, 4, 5, 6, 7, 8, 9}},
-		{IndexFromStart(2), IndexFromEnd(20), nil},
-		{IndexFromEnd(20), IndexFromStart(3), []int{0, 1, 2}},
+		{PositionFromStart(2), PositionFromStart(7), []int{2, 3, 4, 5, 6}},
+		{PositionFromStart(2), PositionFromEnd(3), []int{2, 3, 4, 5, 6}},
+		{PositionFromEnd(7), PositionFromEnd(3), []int{3, 4, 5, 6}},
+		{PositionFromEnd(7), PositionFromStart(8), []int{3, 4, 5, 6, 7}},
+		{PositionFromStart(0), PositionFromEnd(0), input},
+		{PositionFromStart(20), PositionFromEnd(0), nil},
+		{PositionFromEnd(20), PositionFromEnd(0), input},
+		{PositionFromEnd(2), PositionFromEnd(5), nil},
+		{PositionFromStart(7), PositionFromStart(2), nil},
+		{PositionFromStart(2), PositionFromStart(20), []int{2, 3, 4, 5, 6, 7, 8, 9}},
+		{PositionFromStart(2), PositionFromEnd(20), nil},
+		{PositionFromEnd(20), PositionFromStart(3), []int{0, 1, 2}},
 	}
 
 	sources := []Query[int]{
@@ -112,10 +112,10 @@ func TestTakeRangeFromStartStopsAtEnd(t *testing.T) {
 	q := FromSlice([]int{0, 1, 2, 3, 4, 5}).Where(func(int) bool {
 		pulled++
 		return true
-	}).TakeRange(IndexFromStart(2), IndexFromStart(5))
+	}).TakeRange(PositionFromStart(2), PositionFromStart(5))
 
 	if got := q.ToSlice(); !slices.Equal(got, []int{2, 3, 4}) {
-		t.Errorf("TakeRange(IndexFromStart(2), IndexFromStart(5))=%v expected [2 3 4]", got)
+		t.Errorf("TakeRange(PositionFromStart(2), PositionFromStart(5))=%v expected [2 3 4]", got)
 	}
 	if pulled != 5 {
 		t.Errorf("source pulled %d elements expected 5", pulled)

--- a/take_test.go
+++ b/take_test.go
@@ -77,18 +77,18 @@ func TestTakeRange(t *testing.T) {
 		end   Position
 		want  []int
 	}{
-		{PositionFromStart(2), PositionFromStart(7), []int{2, 3, 4, 5, 6}},
-		{PositionFromStart(2), PositionFromEnd(3), []int{2, 3, 4, 5, 6}},
-		{PositionFromEnd(7), PositionFromEnd(3), []int{3, 4, 5, 6}},
-		{PositionFromEnd(7), PositionFromStart(8), []int{3, 4, 5, 6, 7}},
-		{PositionFromStart(0), PositionFromEnd(0), input},
-		{PositionFromStart(20), PositionFromEnd(0), nil},
-		{PositionFromEnd(20), PositionFromEnd(0), input},
-		{PositionFromEnd(2), PositionFromEnd(5), nil},
-		{PositionFromStart(7), PositionFromStart(2), nil},
-		{PositionFromStart(2), PositionFromStart(20), []int{2, 3, 4, 5, 6, 7, 8, 9}},
-		{PositionFromStart(2), PositionFromEnd(20), nil},
-		{PositionFromEnd(20), PositionFromStart(3), []int{0, 1, 2}},
+		{FromStart(2), FromStart(7), []int{2, 3, 4, 5, 6}},
+		{FromStart(2), FromEnd(3), []int{2, 3, 4, 5, 6}},
+		{FromEnd(7), FromEnd(3), []int{3, 4, 5, 6}},
+		{FromEnd(7), FromStart(8), []int{3, 4, 5, 6, 7}},
+		{FromStart(0), FromEnd(0), input},
+		{FromStart(20), FromEnd(0), nil},
+		{FromEnd(20), FromEnd(0), input},
+		{FromEnd(2), FromEnd(5), nil},
+		{FromStart(7), FromStart(2), nil},
+		{FromStart(2), FromStart(20), []int{2, 3, 4, 5, 6, 7, 8, 9}},
+		{FromStart(2), FromEnd(20), nil},
+		{FromEnd(20), FromStart(3), []int{0, 1, 2}},
 	}
 
 	sources := []Query[int]{
@@ -112,10 +112,10 @@ func TestTakeRangeFromStartStopsAtEnd(t *testing.T) {
 	q := FromSlice([]int{0, 1, 2, 3, 4, 5}).Where(func(int) bool {
 		pulled++
 		return true
-	}).TakeRange(PositionFromStart(2), PositionFromStart(5))
+	}).TakeRange(FromStart(2), FromStart(5))
 
 	if got := q.ToSlice(); !slices.Equal(got, []int{2, 3, 4}) {
-		t.Errorf("TakeRange(PositionFromStart(2), PositionFromStart(5))=%v expected [2 3 4]", got)
+		t.Errorf("TakeRange(FromStart(2), FromStart(5))=%v expected [2 3 4]", got)
 	}
 	if pulled != 5 {
 		t.Errorf("source pulled %d elements expected 5", pulled)

--- a/zip.go
+++ b/zip.go
@@ -31,3 +31,33 @@ func (q Query[T]) Zip[TSecond, TResult any](q2 Query[TSecond],
 		},
 	}
 }
+
+// Zip3 applies resultSelector to corresponding elements from three
+// collections. It stops when the shortest collection ends.
+func (q Query[T]) Zip3[TSecond, TThird, TResult any](q2 Query[TSecond],
+	q3 Query[TThird], resultSelector func(T, TSecond, TThird) TResult) Query[TResult] {
+	return Query[TResult]{
+		Iterate: func(yield func(TResult) bool) {
+			next2, stop2 := iter.Pull(q2.Iterate)
+			defer stop2()
+
+			next3, stop3 := iter.Pull(q3.Iterate)
+			defer stop3()
+
+			q.Iterate(func(item T) bool {
+				item2, ok2 := next2()
+				if !ok2 {
+					return false
+				}
+
+				item3, ok3 := next3()
+				if !ok3 {
+					return false
+				}
+
+				return yield(resultSelector(item, item2, item3))
+			})
+		},
+		size: min(q.size, q2.size, q3.size),
+	}
+}

--- a/zip_test.go
+++ b/zip_test.go
@@ -25,3 +25,70 @@ func TestZip_TypeChanging(t *testing.T) {
 		t.Errorf("Zip()=%v expected %v", toSlice(q), want)
 	}
 }
+
+func TestZip3(t *testing.T) {
+	type triple struct {
+		number int
+		word   string
+		flag   bool
+	}
+
+	tests := []struct {
+		numbers []int
+		words   []string
+		flags   []bool
+		want    []triple
+	}{
+		// first is shortest
+		{[]int{1}, []string{"one", "two"}, []bool{true, false},
+			[]triple{{1, "one", true}}},
+		// second is shortest
+		{[]int{1, 2, 3}, []string{"one"}, []bool{true, false, false},
+			[]triple{{1, "one", true}}},
+		// third is shortest
+		{[]int{1, 2, 3}, []string{"one", "two", "three", "four"}, []bool{true, false},
+			[]triple{{1, "one", true}, {2, "two", false}}},
+	}
+
+	for _, test := range tests {
+		q := FromSlice(test.numbers).Zip3(
+			FromSlice(test.words),
+			FromSlice(test.flags),
+			func(number int, word string, flag bool) triple {
+				return triple{number, word, flag}
+			},
+		)
+		if !testQueryIteration(q, test.want) {
+			t.Errorf("Zip3(%v, %v, %v)=%v expected %v",
+				test.numbers, test.words, test.flags, toSlice(q), test.want)
+		}
+	}
+}
+
+func TestZip3StopsAllSources(t *testing.T) {
+	pulledSecond := 0
+	pulledThird := 0
+	second := FromSlice([]int{10, 20, 30}).Where(func(int) bool {
+		pulledSecond++
+		return true
+	})
+	third := FromSlice([]int{100, 200, 300}).Where(func(int) bool {
+		pulledThird++
+		return true
+	})
+
+	var got []int
+	FromSlice([]int{1, 2, 3}).Zip3(second, third, func(a, b, c int) int {
+		return a + b + c
+	}).Iterate(func(item int) bool {
+		got = append(got, item)
+		return false
+	})
+
+	if len(got) != 1 || got[0] != 111 {
+		t.Errorf("Zip3 early exit yielded %v expected [111]", got)
+	}
+	if pulledSecond != 1 || pulledThird != 1 {
+		t.Errorf("Zip3 pulled second=%d third=%d expected 1 each", pulledSecond, pulledThird)
+	}
+}


### PR DESCRIPTION
Hi @ahmetb, I originally hoped to have this ready before the v5.0.0 release, but unfortunately I did not make it in time.

Since v5.0.0 is already published, I suggest releasing these additions as v5.1.0. If you would prefer to re-release v5.0.0 instead, I can adjust the release notes accordingly, although v5.1.0 seems like the safer option now that the existing tag is public.

## Summary

Builds on the generic v5 API and adds the remaining LINQ operators introduced in .NET 6 through .NET 11.

## Highlights

- .NET 6: `Chunk`, `SkipLast`, `TakeLast`, `ElementAt`, `TakeRange`, `Zip3`, and the custom-comparer variants `MinWith`, `MaxWith`, `MinByWith`, and `MaxByWith`.
- .NET 7: stable `Order`/`OrderDescending` and comparer-based `OrderWith`/`OrderDescendingWith`.
- .NET 9: `CountBy`, `AggregateBy`, `AggregateByWithSeedSelector`, and `Index`.
- .NET 10: `LeftJoin`, `RightJoin`, `Sequence`, `InfiniteSequence`, and `Shuffle`.
- .NET 11: `FullJoin`.
- Adds `Empty`, `ToHashSet`, `ToHashSetBy`, and the chainable `ChunkBy`.
- Adds `Position` with `FromStart`/`FromEnd` constructors for index and range operations.

## Behavior changes

- `OrderBy`, `OrderByDescending`, `ThenBy`, and `ThenByDescending` are now stable, matching .NET LINQ.
- Joins no longer match nil keys, including typed nil values stored in interfaces, matching .NET LINQ.
- Size hints and early-termination behavior are preserved across the new operators.
- Trailing buffers are bounded by the available source size.

## Documentation

- Adds Go-specific API guidance for package-level operators and their chainable counterparts.
- Updates migration notes, performance details, examples, and v5.1.0 release notes.
